### PR TITLE
[@remote-dom/react] Fix a bug where props were not updated using react integration

### DIFF
--- a/packages/react/source/component.tsx
+++ b/packages/react/source/component.tsx
@@ -130,7 +130,7 @@ export function createRemoteComponent<
           lastRemotePropertiesRef.current ?? remoteProperties;
 
         for (const prop in propsToUpdate) {
-          internalRef.current[prop] = remoteProperties[prop];
+          internalRef.current.setAttribute(prop, remoteProperties[prop]);
         }
 
         lastRemotePropertiesRef.current = remoteProperties;


### PR DESCRIPTION
I was testing this library and found _possibly_ a bug in the logic for updating props using the react integration. It appears that directly setting the prop on the custom `Element` does not update the attribute.

```
// Does not work
element[prop] = propValue;

// Works
element.setAttribute(prop, propValue);
```

I was able to reproduce the issue on both Chrome v123 and FireFox v123

<details>
<summary>
<h3>My test code</h3>
</summary>

Here's my host code:

```ts
export const RemoteBox = ({
  padding = "none",
  color = "base",
  rounded = "none",
  children,
  ...props
}: RemoteBoxProps) => {
  return (
     // ...
  );
};

export const remoteBoxComponentTuple = [
  "ui-box",
  createRemoteComponentRenderer(RemoteBox),
] as const;

```

And the iframe code:

```ts

class BoxElement extends RemoteElement<RemoteBoxProps> {
  static get remoteProperties() {
    return ["color", "padding", "rounded"];
  }

  static get remoteSlots() {
    return ["children"];
  }
}

export const Box = createRemoteComponent("ui-box" as any, BoxElement);

export function Wrapper({
  data,
  componentName,
}: {
  data: any;
  componentName: string;
}) {
  return (
    <Box color="blue" padding="lg" rounded="lg">
      Hello
    </Box>
  );
}
```
</details>

In my example code, the `color`, `padding`, and `rounded` props where not getting applied to the custom element, hence the host mirrored element was not receiving any updates.

| Before | After (non-children props are transferred) |
| -- | -- |
| <img width="532" alt="Screenshot 2024-04-16 at 11 41 12 AM" src="https://github.com/Shopify/remote-dom/assets/6104558/a0165675-a027-4bb5-a5cb-3426a16807d5"> | <img width="312" alt="Screenshot 2024-04-16 at 11 44 36 AM" src="https://github.com/Shopify/remote-dom/assets/6104558/d22c605e-0fcc-4687-98ef-e3a49f5ebe84"> |