### PR TITLE
Remove mentions of Preact in React package

### DIFF
--- a/packages/react/source/component.tsx
+++ b/packages/react/source/component.tsx
@@ -18,9 +18,9 @@ import type {
 
 export interface RemoteComponentOptions {
   /**
-   * Customize how Preact props are mapped to slotted child elements. By default,
+   * Customize how React props are mapped to slotted child elements. By default,
    * any prop that is listed in the remote element’s class definition, and which
-   * contains a valid Preact element, is turned into a `<remote-fragment>` element
+   * contains a valid React element, is turned into a `<remote-fragment>` element
    * with a `slot` attribute set to the name of the prop. You disable this behavior
    * entirely by setting this option to `false`, or customize the tag name of the
    * wrapper element by passing the `wrapper` option.
@@ -32,7 +32,7 @@ export interface RemoteComponentOptions {
     | {
         /**
          * Customizes the wrapper element used on a slotted element. If `true` or omitted,
-         * the wrapper element will be a `<remote-fragment>` element. If `false`, the Preact
+         * the wrapper element will be a `<remote-fragment>` element. If `false`, the React
          * element will be cloned with a `slot` prop. If a string, that wrapper element will
          * be created.
          *
@@ -43,9 +43,9 @@ export interface RemoteComponentOptions {
 }
 
 /**
- * Creates a Preact component that renders a remote DOM element. This component will pass
- * through all the props from the Preact component to the remote DOM element, and will
- * convert any props that are Preact elements into a `remote-fragment` element with a `slot`
+ * Creates a React component that renders a remote DOM element. This component will pass
+ * through all the props from the React component to the remote DOM element, and will
+ * convert any props that are React elements into a `remote-fragment` element with a `slot`
  * attribute that matches the prop name.
  *
  * @param tag The name of the remote DOM element to render

--- a/packages/react/source/host/component.tsx
+++ b/packages/react/source/host/component.tsx
@@ -16,7 +16,7 @@ import {
 import type {RemoteComponentRendererProps} from './types.ts';
 
 /**
- * Additional props that are added to Preact components rendered by `createRemoteComponentRenderer`.
+ * Additional props that are added to React components rendered by `createRemoteComponentRenderer`.
  */
 export interface RemoteComponentRendererAdditionalProps {
   /**

--- a/packages/react/source/host/constants.ts
+++ b/packages/react/source/host/constants.ts
@@ -1,5 +1,5 @@
 /**
- * The property name used to pass a remote element instance to the Preact component
+ * The property name used to pass a remote element instance to the React component
  * that is configured to render it.
  */
 export const REMOTE_ELEMENT_PROP = Symbol.for('remote-dom.element');

--- a/packages/react/source/host/hooks/props-for-element.tsx
+++ b/packages/react/source/host/hooks/props-for-element.tsx
@@ -6,7 +6,7 @@ import type {RemoteNodeRenderOptions} from '../types.ts';
 /**
  * Converts a remote element into props for a React element. In addition to passing along
  * the `properties` of that element, this hook will convert any child elements with a `slot`
- * property into a prop of the same name, with the value rendered to a Preact element.
+ * property into a prop of the same name, with the value rendered to a React element.
  */
 export function usePropsForRemoteElement<
   Props extends Record<string, any> = {},

--- a/packages/react/source/host/types.ts
+++ b/packages/react/source/host/types.ts
@@ -14,13 +14,13 @@ export interface RemoteNodeRenderOptions {
   receiver: RemoteReceiver;
 
   /**
-   * A map of Preact components that can render remote elements.
+   * A map of React components that can render remote elements.
    */
   components: RemoteComponentRendererMap<any>;
 }
 
 /**
- * The props that are passed to a Preact component in order to render
+ * The props that are passed to a React component in order to render
  * a remote element.
  */
 export interface RemoteComponentRendererProps extends RemoteNodeRenderOptions {

--- a/packages/react/source/tests/e2e.test.tsx
+++ b/packages/react/source/tests/e2e.test.tsx
@@ -274,7 +274,7 @@ describe('react', () => {
     expect(closeSpy).toHaveBeenCalled();
   });
 
-  it('can remove the wrapper element on elements passed as properties to remote Preact components', async () => {
+  it('can remove the wrapper element on elements passed as properties to remote React components', async () => {
     const RemoteModalWithoutWrappers = createRemoteComponent(
       'remote-modal',
       RemoteModalElement,
@@ -310,7 +310,7 @@ describe('react', () => {
     expect(rendered).toContainReactComponent(RemoteButton, {slot: 'action'});
   });
 
-  it('can change the wrapper element on elements passed as properties to remote Preact components', async () => {
+  it('can change the wrapper element on elements passed as properties to remote React components', async () => {
     const RemoteModalWithoutWrappers = createRemoteComponent(
       'remote-modal',
       RemoteModalElement,

--- a/packages/react/source/types.ts
+++ b/packages/react/source/types.ts
@@ -7,9 +7,9 @@ import type {
 } from '@remote-dom/core/elements';
 
 /**
- * The props that will be passed to a Preact component when it is rendered
+ * The props that will be passed to a React component when it is rendered
  * in response to a remote element. This type includes all the remote properties
- * of the underlying element, and any slotted children, converted to Preact elements
+ * of the underlying element, and any slotted children, converted to React elements
  * passed as properties with the same name as their slot.
  */
 export type RemoteComponentProps<
@@ -23,7 +23,7 @@ export type RemoteComponentProps<
 };
 
 /**
- * Converts the type for a remote element into the full set of Preact props that
+ * Converts the type for a remote element into the full set of React props that
  * will be passed to a component that renders that element.
  */
 export type RemoteComponentPropsFromElementConstructor<
@@ -35,7 +35,7 @@ export type RemoteComponentPropsFromElementConstructor<
 > & {ref?: Ref<InstanceType<ElementConstructor>>; slot?: string};
 
 /**
- * Converts the type for a remote element into the type of a Preact component that
+ * Converts the type for a remote element into the type of a React component that
  * can be used to render that element.
  */
 export type RemoteComponentTypeFromElementConstructor<


### PR DESCRIPTION
It looks like some comments were copied from the Preact implementation and should mention React instead.

I also noticed that Preact is listed as a dev dep in `@remote-dom/react` but isn't used:

https://github.com/Shopify/remote-dom/blob/daf2007f794e5a5ebc403f3412cc65ed5bd959bf/packages/react/package.json#L82

Happy to fix this as well. 

I'm also not sure if this warrants a changeset, let me know.