### PR TITLE
Expose BatchingRemoteConnection and add missing call method

### DIFF
--- a/packages/core/source/elements.ts
+++ b/packages/core/source/elements.ts
@@ -35,3 +35,5 @@ export {customElement} from './elements/decorators/custom-element.ts';
 export {BooleanOrString} from './elements/property-types/BooleanOrString.ts';
 
 export type {RemoteConnection} from './types.ts';
+
+export {BatchingRemoteConnection} from './elements/connection.ts';

--- a/packages/core/source/elements/connection.ts
+++ b/packages/core/source/elements/connection.ts
@@ -20,6 +20,10 @@ export class BatchingRemoteConnection {
     this.#batch = batch;
   }
 
+  call(id: string, method: string, ...args: readonly unknown[]) {
+    this.#connection.call(id, method, ...args);
+  }
+
   mutate(records: any[]) {
     let queued = this.#queued;
 


### PR DESCRIPTION
We were currently not exporting the `BatchingRemoteConnection` and the instance was missing a `call` method. This PR fixes those issues.