### PR TITLE
Add CommonJS export conditions

### DIFF
--- a/.changeset/yellow-comics-admire.md
+++ b/.changeset/yellow-comics-admire.md
@@ -1,0 +1,9 @@
+---
+'@remote-dom/polyfill': minor
+'@remote-dom/signals': minor
+'@remote-dom/preact': minor
+'@remote-dom/react': minor
+'@remote-dom/core': minor
+---
+
+Add CommonJS export conditions

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,25 +28,29 @@
       "types": "./build/typescript/elements.d.ts",
       "quilt:source": "./source/elements.ts",
       "quilt:esnext": "./build/esnext/elements.esnext",
-      "import": "./build/esm/elements.mjs"
+      "import": "./build/esm/elements.mjs",
+      "require": "./build/cjs/elements.cjs"
     },
     "./html": {
       "types": "./build/typescript/html.d.ts",
       "quilt:source": "./source/html.ts",
       "quilt:esnext": "./build/esnext/html.esnext",
-      "import": "./build/esm/html.mjs"
+      "import": "./build/esm/html.mjs",
+      "require": "./build/cjs/html.cjs"
     },
     "./polyfill": {
       "types": "./build/typescript/polyfill.d.ts",
       "quilt:source": "./source/polyfill.ts",
       "quilt:esnext": "./build/esnext/polyfill.esnext",
-      "import": "./build/esm/polyfill.mjs"
+      "import": "./build/esm/polyfill.mjs",
+      "require": "./build/cjs/polyfill.cjs"
     },
     "./receivers": {
       "types": "./build/typescript/receivers.d.ts",
       "quilt:source": "./source/receivers.ts",
       "quilt:esnext": "./build/esnext/receivers.esnext",
-      "import": "./build/esm/receivers.mjs"
+      "import": "./build/esm/receivers.mjs",
+      "require": "./build/cjs/receivers.cjs"
     }
   },
   "types": "./build/typescript/index.d.ts",

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -1,3 +1,3 @@
 import {quiltPackage} from '@quilted/rollup/package';
 
-export default quiltPackage();
+export default quiltPackage({commonjs: true});

--- a/packages/polyfill/package.json
+++ b/packages/polyfill/package.json
@@ -21,7 +21,8 @@
       "types": "./build/typescript/index.d.ts",
       "quilt:source": "./source/index.ts",
       "quilt:esnext": "./build/esnext/index.esnext",
-      "import": "./build/esm/index.mjs"
+      "import": "./build/esm/index.mjs",
+      "require": "./build/cjs/index.cjs"
     }
   },
   "types": "./build/typescript/index.d.ts",

--- a/packages/polyfill/rollup.config.js
+++ b/packages/polyfill/rollup.config.js
@@ -1,3 +1,3 @@
 import {quiltPackage} from '@quilted/rollup/package';
 
-export default quiltPackage();
+export default quiltPackage({commonjs: true});

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -21,19 +21,22 @@
       "types": "./build/typescript/index.d.ts",
       "quilt:source": "./source/index.ts",
       "quilt:esnext": "./build/esnext/index.esnext",
-      "import": "./build/esm/index.mjs"
+      "import": "./build/esm/index.mjs",
+      "require": "./build/cjs/index.cjs"
     },
     "./host": {
       "types": "./build/typescript/host.d.ts",
       "quilt:source": "./source/host.ts",
       "quilt:esnext": "./build/esnext/host.esnext",
-      "import": "./build/esm/host.mjs"
+      "import": "./build/esm/host.mjs",
+      "require": "./build/cjs/host.cjs"
     },
     "./html": {
       "types": "./build/typescript/html.d.ts",
       "quilt:source": "./source/html.ts",
       "quilt:esnext": "./build/esnext/html.esnext",
-      "import": "./build/esm/html.mjs"
+      "import": "./build/esm/html.mjs",
+      "require": "./build/cjs/html.cjs"
     }
   },
   "types": "./build/typescript/index.d.ts",

--- a/packages/preact/rollup.config.js
+++ b/packages/preact/rollup.config.js
@@ -2,4 +2,5 @@ import {quiltPackage} from '@quilted/rollup/package';
 
 export default quiltPackage({
   react: 'preact',
+  commonjs: true,
 });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -20,25 +20,29 @@
       "types": "./build/typescript/index.d.ts",
       "quilt:source": "./source/index.ts",
       "quilt:esnext": "./build/esnext/index.esnext",
-      "import": "./build/esm/index.mjs"
+      "import": "./build/esm/index.mjs",
+      "require": "./build/cjs/index.cjs"
     },
     "./host": {
       "types": "./build/typescript/host.d.ts",
       "quilt:source": "./source/host.ts",
       "quilt:esnext": "./build/esnext/host.esnext",
-      "import": "./build/esm/host.mjs"
+      "import": "./build/esm/host.mjs",
+      "require": "./build/cjs/host.cjs"
     },
     "./html": {
       "types": "./build/typescript/html.d.ts",
       "quilt:source": "./source/html.ts",
       "quilt:esnext": "./build/esnext/html.esnext",
-      "import": "./build/esm/html.mjs"
+      "import": "./build/esm/html.mjs",
+      "require": "./build/cjs/html.cjs"
     },
     "./polyfill": {
       "types": "./build/typescript/polyfill.d.ts",
       "quilt:source": "./source/polyfill.ts",
       "quilt:esnext": "./build/esnext/polyfill.esnext",
-      "import": "./build/esm/polyfill.mjs"
+      "import": "./build/esm/polyfill.mjs",
+      "require": "./build/cjs/polyfill.cjs"
     }
   },
   "types": "./build/typescript/index.d.ts",

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -1,3 +1,3 @@
 import {quiltPackage} from '@quilted/rollup/package';
 
-export default quiltPackage();
+export default quiltPackage({commonjs: true});

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -20,7 +20,8 @@
       "types": "./build/typescript/index.d.ts",
       "quilt:source": "./source/index.ts",
       "quilt:esnext": "./build/esnext/index.esnext",
-      "import": "./build/esm/index.mjs"
+      "import": "./build/esm/index.mjs",
+      "require": "./build/cjs/index.cjs"
     }
   },
   "types": "./build/typescript/index.d.ts",

--- a/packages/signals/rollup.config.js
+++ b/packages/signals/rollup.config.js
@@ -1,3 +1,3 @@
 import {quiltPackage} from '@quilted/rollup/package';
 
-export default quiltPackage();
+export default quiltPackage({commonjs: true});


### PR DESCRIPTION
Does what it says on the tin. Supports Shopify host applications that use Jest, or have some other need to run Node in non-ESM mode. The ESM outputs are still preferred, so they appear first in the list of export conditions.