### PR TITLE
Fix `slot` to be transmitted as an attribute, not a property

### DIFF
--- a/.changeset/pink-dryers-fix.md
+++ b/.changeset/pink-dryers-fix.md
@@ -1,0 +1,6 @@
+---
+'@remote-dom/preact': patch
+'@remote-dom/core': patch
+---
+
+Fix `slot` to be transmitted as an attribute, not a property

--- a/packages/core/source/elements/RemoteElement.ts
+++ b/packages/core/source/elements/RemoteElement.ts
@@ -643,7 +643,7 @@ export abstract class RemoteElement<
       attribute === 'slot' &&
       (this.constructor as typeof RemoteElement).slottable
     ) {
-      updateRemoteElementProperty(
+      updateRemoteElementAttribute(
         this,
         attribute,
         newValue ? String(newValue) : undefined,

--- a/packages/core/source/tests/elements.test.ts
+++ b/packages/core/source/tests/elements.test.ts
@@ -788,6 +788,32 @@ describe('RemoteElement', () => {
       ]);
     });
 
+    it('automatically serializes the slot attribute without any additional configuration', () => {
+      const ProductElement = createRemoteElement();
+
+      const receiver = new TestRemoteReceiver();
+
+      const root = createRemoteRootElement();
+      const element = createElementFromConstructor(ProductElement);
+      root.append(element);
+
+      const slot = 'aside';
+      element.setAttribute('slot', slot);
+
+      root.connect(receiver.connection);
+
+      expect(receiver.connection.mutate).toHaveBeenLastCalledWith([
+        [
+          MUTATION_TYPE_INSERT_CHILD,
+          remoteId(root),
+          expect.objectContaining({
+            attributes: {slot},
+          }),
+          0,
+        ],
+      ]);
+    });
+
     it('reflects the value of a remote attribute automatically when the attribute is set', () => {
       const ProductElement = createRemoteElement({
         attributes: ['name'],

--- a/packages/preact/source/host/hooks/props-for-element.tsx
+++ b/packages/preact/source/host/hooks/props-for-element.tsx
@@ -87,7 +87,7 @@ export function usePropsForRemoteElement<
 
   for (const child of children.value) {
     let slot: string | undefined =
-      child.type === 1 ? (child.properties.peek().slot as any) : undefined;
+      child.type === 1 ? (child.attributes.peek().slot as any) : undefined;
 
     if (typeof slot !== 'string') slot = undefined;
 


### PR DESCRIPTION
While debugging Customer Accounts with @robin-drexler, we noticed that the React host utilities were expecting the `slot` of an element to be available in its `attributes` https://github.com/Shopify/remote-dom/blob/main/packages/react/source/host/hooks/props-for-element.tsx#L85, but the core library was actually sending it as a property instead. The Preact version was looking at the property as well, so this issue was hidden when playing with the comprehensive example, which uses Preact on the host (even when using React for the example).

To fix this, I am aligning everything to send/ read `slot` as an attribute, not a property.