### PR TITLE
fix(Window.setGlobal): window aliases should refer to globalThis

### DIFF
--- a/packages/polyfill/source/Window.ts
+++ b/packages/polyfill/source/Window.ts
@@ -21,6 +21,7 @@ import type {Hooks} from './hooks.ts';
 export class Window extends EventTarget {
   [HOOKS]: Partial<Hooks> = {};
   name = '';
+  window = this;
   parent = this;
   self = this;
   top = this;
@@ -46,32 +47,14 @@ export class Window extends EventTarget {
   MutationObserver = MutationObserver;
 
   static setGlobal(window: Window) {
+    for (const property in window) {
+      if (window[property] === window) {
+        window[property] = globalThis;
+      }
+    }
+
     const properties = Object.getOwnPropertyDescriptors(window);
 
-    delete (properties as any).self;
-
-    Object.defineProperties(globalThis, {
-      ...properties,
-      window: {
-        value: window,
-        configurable: true,
-        writable: true,
-        enumerable: true,
-      },
-    });
-
-    if (typeof self === 'undefined') {
-      Object.defineProperty(globalThis, 'self', {
-        value: window,
-        configurable: true,
-        writable: true,
-        enumerable: true,
-      });
-    } else {
-      // There can already be a `self`, like when polyfilling the DOM
-      // in a Web Worker. In those cases, just mirror all the `Window`
-      // properties onto `self`, rather than wholly redefining it.
-      Object.defineProperties(self, properties);
-    }
+    Object.defineProperties(globalThis, properties);
   }
 }


### PR DESCRIPTION
all of the following must be true:

```
window.window === window
globalThis.window === globalThis
globalThis.self === globalThis.window
```