### PR TITLE
Fix references after node removal

### DIFF
--- a/.changeset/serious-ladybugs-bow.md
+++ b/.changeset/serious-ladybugs-bow.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/polyfill': patch
+---
+
+Fix removeChild so it clears parent/sibling references

--- a/.changeset/warm-oranges-rest.md
+++ b/.changeset/warm-oranges-rest.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/polyfill': patch
+---
+
+Add node.parentElement

--- a/packages/polyfill/source/Node.ts
+++ b/packages/polyfill/source/Node.ts
@@ -62,6 +62,14 @@ export class Node extends EventTarget {
 
   set parentNode(_readonly) {}
 
+  get parentElement() {
+    let parent = this[PARENT];
+    while (parent && parent.nodeType !== 1) parent = parent[PARENT];
+    return parent;
+  }
+
+  set parentElement(_readonly) {}
+
   get previousSibling() {
     return this[PREV];
   }

--- a/packages/polyfill/source/Node.ts
+++ b/packages/polyfill/source/Node.ts
@@ -62,9 +62,9 @@ export class Node extends EventTarget {
 
   set parentNode(_readonly) {}
 
-  get parentElement() {
-    let parent = this[PARENT];
-    while (parent && parent.nodeType !== 1) parent = parent[PARENT];
+  get parentElement(): ParentNode | null {
+    const parent = this[PARENT];
+    if (!parent || parent.nodeType !== 1) return null;
     return parent;
   }
 

--- a/packages/polyfill/source/ParentNode.ts
+++ b/packages/polyfill/source/ParentNode.ts
@@ -68,6 +68,10 @@ export class ParentNode extends ChildNode {
       children.splice(children.indexOf(child), 1);
     }
 
+    child[PARENT] = null;
+    child[NEXT] = null;
+    child[PREV] = null;
+
     if (this[IS_CONNECTED]) {
       for (const node of selfAndDescendants(child)) {
         node[IS_CONNECTED] = false;


### PR DESCRIPTION
Prior to this:

- `parentNode`
- `nextSibling`
- `previousSibling`
- `nextElementSibling`
- `previousElementSibling`

…remained set when removing an element from its parent.

I also added `node.parentElement`.