### PR TITLE
Make react example use react

### DIFF
--- a/examples/kitchen-sink/app/remote/examples/react.tsx
+++ b/examples/kitchen-sink/app/remote/examples/react.tsx
@@ -1,6 +1,7 @@
 /** @jsxRuntime automatic */
 /** @jsxImportSource react */
 
+import '@remote-dom/react/polyfill';
 import {useState, useRef} from 'react';
 import {createRoot} from 'react-dom/client';
 import {createRemoteComponent} from '@remote-dom/react';

--- a/examples/kitchen-sink/vite.config.js
+++ b/examples/kitchen-sink/vite.config.js
@@ -11,6 +11,7 @@ export default defineConfig({
   },
   plugins: [
     preact({
+      reactAliasesEnabled: false,
       // We manually set the JSX transformation to apply to examples per-file
       exclude: ['remote/examples/*.tsx'],
     }),


### PR DESCRIPTION
`@preact/preset-vite` by default aliases `react` to `preact` so react example in kitchen sink was actually using preact under the hood.