### PR TITLE
Apply React polyfill directly to `globalThis`

### DIFF
--- a/.changeset/sharp-frogs-bathe.md
+++ b/.changeset/sharp-frogs-bathe.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/react': patch
+---
+
+Apply React polyfill directly to `globalThis`


### PR DESCRIPTION
This PR updates the React polyfill to apply directly to `globalThis`. This fixes a bug that resulted from shipping https://github.com/Shopify/remote-dom/pull/470, since the additional polyfills added by `@remote-dom/react/polyfill` (in particular, the one for `HTMLIframeElement`) were only being applied to the polyfilled `Window` class, not to `globalThis`.