### PR TITLE
Add type-check to snapit builds

### DIFF
--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -23,5 +23,5 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
-          build_script: pnpm build
+          build_script: pnpm type-check || true && pnpm build
           comment_command: /snapit


### PR DESCRIPTION
Current snapit builds are missing the types as `type-check` is never run.