### PR TITLE
Fix snapit script

### DIFF
--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -23,5 +23,5 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
-          build_script: pnpm type-check || true && pnpm build
+          build_script: pnpm build:snapit
           comment_command: /snapit

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   ],
   "scripts": {
     "build": "pnpm -r run build",
+    "build:snapit": "pnpm type-check || true && pnpm build",
     "format": "prettier --write --cache .",
     "lint": "prettier --check --cache .",
     "test": "vitest",


### PR DESCRIPTION
Current iteration of snapit can't handle logic in commands. The quickest workaround is to extract the command into an npm script.