### PR TITLE
Move internal peer dependencies to dependencies

### DIFF
--- a/.changeset/itchy-ears-crash.md
+++ b/.changeset/itchy-ears-crash.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/signals': patch
+---
+
+Move internal peer dependencies to dependencies

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -29,22 +29,20 @@
     "build": "rollup --config ./rollup.config.js"
   },
   "peerDependencies": {
-    "@preact/signals-core": "^1.3.0",
-    "@remote-dom/core": "workspace:^1.6.1"
+    "@preact/signals-core": "^1.3.0"
   },
   "peerDependenciesMeta": {
     "@preact/signals-core": {
       "optional": true
-    },
-    "@remote-dom/core": {
-      "optional": true
     }
   },
   "devDependencies": {
-    "@preact/signals-core": "^1.8.0",
-    "@remote-dom/core": "workspace:*"
+    "@preact/signals-core": "^1.8.0"
   },
   "browserslist": [
     "defaults and not dead"
-  ]
+  ],
+  "dependencies": {
+    "@remote-dom/core": "workspace:^1.6.1"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,13 +214,14 @@ importers:
         version: 18.3.1(react@18.3.1)
 
   packages/signals:
+    dependencies:
+      '@remote-dom/core':
+        specifier: workspace:^1.6.1
+        version: link:../core
     devDependencies:
       '@preact/signals-core':
         specifier: ^1.8.0
         version: 1.8.0
-      '@remote-dom/core':
-        specifier: workspace:*
-        version: link:../core
 
 packages:
 


### PR DESCRIPTION
### Description

`changesets` always bumps major version for packages that have their peer dependencies updated.

There's a bunch of filed issues (https://github.com/changesets/changesets/issues/822, https://github.com/changesets/changesets/issues/960, https://github.com/changesets/changesets/issues/1011) and no fix in sight as [the PR](https://github.com/changesets/changesets/pull/1132) that would fix that is ignored by the codeowners since May 2023.

This issue is actually [described in the docs](https://github.com/changesets/changesets/blob/main/docs/decisions.md#the-versioning-of-peer-dependencies), so it's an expected behavior:

> Currently, if you list a package as a `peerDependency` of another package, this causes the package with the `peerDependency` to be released as a major change. This is because `peerDependency` changes will not be caught by a package installation.

### Solution

Move the dependency from `peerDependencies` to `dependencies` at least until the issue is fixed.