### PR TITLE
Unpack fragments in adapter

### DIFF
--- a/.changeset/few-emus-cry.md
+++ b/.changeset/few-emus-cry.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/compat': patch
+---
+
+Unpack fragments in the remote-ui to remot-dom adapter


### PR DESCRIPTION
Update:

This approach makes fragments created in remote-ui in vanilla js render in remote-dom but this differs from the remote-ui behavior that ignores all fragments but the ones passed as a prop.

---

Even though [the types](https://github.com/Shopify/remote-dom/blob/23462622c0cc2f73c2890af8833cdb3367aa2b05/packages/core/src/types.ts#L39) say remote-ui remote can't send fragments, it can, and that is currently not handled by the adapter.

The minimal example that causes remote to send a fragment:

```tsx
const fragment = root.createFragment();
root.appendChild(fragment);
This is not an issue with react on remote as it appears that react-reconciler takes care of unpacking the fragments automatically.
```