### PR TITLE
Handle fragments in adapter

### DIFF
--- a/.changeset/few-emus-cry.md
+++ b/.changeset/few-emus-cry.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/compat': patch
+---
+
+Handle fragments in adapter

--- a/packages/compat/source/adapter/host.ts
+++ b/packages/compat/source/adapter/host.ts
@@ -1,5 +1,6 @@
 import {
   KIND_TEXT as LEGACY_KIND_TEXT,
+  KIND_COMPONENT as LEGACY_KIND_COMPONENT,
   KIND_FRAGMENT as LEGACY_KIND_FRAGMENT,
   ACTION_MOUNT as LEGACY_ACTION_MOUNT,
   ACTION_INSERT_CHILD as LEGACY_ACTION_INSERT_CHILD,
@@ -16,6 +17,7 @@ import {
 import {
   ROOT_ID,
   NODE_TYPE_TEXT,
+  NODE_TYPE_COMMENT,
   NODE_TYPE_ELEMENT,
   MUTATION_TYPE_INSERT_CHILD,
   MUTATION_TYPE_REMOVE_CHILD,
@@ -26,6 +28,7 @@ import {
   type RemoteElementSerialization,
   type RemoteConnection,
   type RemoteNodeSerialization,
+  type RemoteCommentSerialization,
 } from '@remote-dom/core';
 
 export interface LegacyRemoteChannelElementMap {
@@ -213,7 +216,7 @@ export function adaptToLegacyRemoteChannel(
             records.push([
               MUTATION_TYPE_INSERT_CHILD,
               id,
-              adaptLegacyFragmentSerialization(key, value, options),
+              adaptLegacyPropFragmentSerialization(key, value, options),
               tree.get(id)?.length ?? 0,
             ] satisfies RemoteMutationRecord);
           } else {
@@ -246,13 +249,26 @@ export function adaptToLegacyRemoteChannel(
 }
 
 function adaptLegacyNodeSerialization(
-  child: LegacyRemoteComponentSerialization | LegacyRemoteTextSerialization,
+  child:
+    | LegacyRemoteComponentSerialization
+    | LegacyRemoteTextSerialization
+    | LegacyRemoteFragmentSerialization,
   options?: LegacyRemoteChannelOptions,
-): RemoteElementSerialization | RemoteTextSerialization {
-  if (child.kind === LEGACY_KIND_TEXT) {
-    return adaptLegacyTextSerialization(child);
-  } else {
-    return adaptLegacyComponentSerialization(child, options);
+):
+  | RemoteElementSerialization
+  | RemoteTextSerialization
+  | RemoteCommentSerialization {
+  switch (child.kind) {
+    case LEGACY_KIND_TEXT:
+      return adaptLegacyTextSerialization(child);
+    case LEGACY_KIND_COMPONENT:
+      return adaptLegacyComponentSerialization(child, options);
+    default:
+      return {
+        id: child.id,
+        type: NODE_TYPE_COMMENT,
+        data: 'added by remote-ui legacy adaptor to replace a fragment rendered as a child',
+      };
   }
 }
 
@@ -323,11 +339,11 @@ function adaptLegacyFragmentsSerialization(
   options?: LegacyRemoteChannelOptions,
 ): RemoteElementSerialization[] {
   return Object.entries(fragments).map(([slot, fragment]) => {
-    return adaptLegacyFragmentSerialization(slot, fragment, options);
+    return adaptLegacyPropFragmentSerialization(slot, fragment, options);
   });
 }
 
-function adaptLegacyFragmentSerialization(
+function adaptLegacyPropFragmentSerialization(
   slot: string,
   fragment: LegacyRemoteFragmentSerialization,
   options?: LegacyRemoteChannelOptions,


### PR DESCRIPTION
The `remote-ui` to `remote-dom` adapter currently does not expect fragments to be passed and throws an exception when one is encountered. `remote-ui` host does accept fragments and maps them to an `undefined` component resulting in them not getting rendered. The adapter should mimic this behavior.

Note: Instead of an undefined component I went with mapping to a comment node. That achieves the same goal but also makes a bit more sense to me.