### PR TITLE
Check element existence and type before applying mutations in receivers

### DIFF
--- a/.changeset/smart-teachers-repeat.md
+++ b/.changeset/smart-teachers-repeat.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/core': patch
+---
+
+Check element existence and type before applying mutations in receivers


### PR DESCRIPTION
As in https://github.com/Shopify/remote-dom/issues/542 mentioned, there are race conditions during rendering that can lead to updates on already removed elements. This PR fixes this problem by checking the existence of the target element.

Resolves #542 