### PR TITLE
Fix condition for skipping insert mutation

### DIFF
--- a/.changeset/blue-ligers-exist.md
+++ b/.changeset/blue-ligers-exist.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/core': patch
+---
+
+Fix condition for skipping insert mutation

--- a/packages/core/source/elements/RemoteMutationObserver.ts
+++ b/packages/core/source/elements/RemoteMutationObserver.ts
@@ -34,7 +34,6 @@ import type {RemoteConnection, RemoteMutationRecord} from '../types.ts';
 export class RemoteMutationObserver extends MutationObserver {
   constructor(private readonly connection: RemoteConnection) {
     super((records) => {
-      const addedNodes: Node[] = [];
       const remoteRecords: RemoteMutationRecord[] = [];
 
       for (const record of records) {
@@ -55,21 +54,7 @@ export class RemoteMutationObserver extends MutationObserver {
             ]);
           });
 
-          // A mutation observer will queue some changes, so we might get one record
-          // for attaching a parent element, and additional records for attaching descendants.
-          // We serialize the entire tree when a new node was added, so we don’t want to
-          // send additional “insert child” records when we see those descendants — they
-          // will already be included the insertion of the parent.
           record.addedNodes.forEach((node, index) => {
-            if (
-              addedNodes.some((addedNode) => {
-                return addedNode === node || addedNode.contains(node);
-              })
-            ) {
-              return;
-            }
-
-            addedNodes.push(node);
             connectRemoteNode(node, connection);
 
             remoteRecords.push([


### PR DESCRIPTION
As stated in [this comment](https://github.com/Shopify/remote-dom/blob/main/packages/core/source/elements/RemoteMutationObserver.ts#L58) detected insertions of nodes are skipped, if a node is a child of an already inserted node, or if the node has already been added.

This seems to be a valid optimization to reduce the number of mutation records. Unfortunately skipping MutationRecords in general is not a good idea and will lead to inconsistencies and errors, especially when there are several batched mutations as a result of nodes being removed and added again in short period of time.

This is a simplified real world example, where skipping the insertion of a child node (B) will eventually result in a missing node.

```
1. INSERT
   Node A
   ├─ Node B

2. REMOVE
   Node B

3. INSERT (this could not be skipped)
   Node B
```

These issues, are very likely a consequence of this behavior:

- https://github.com/Shopify/remote-dom/issues/542
- https://github.com/Shopify/remote-dom/issues/519