### PR TITLE
Throw better errors on the RESULT and FUNCTION_RESULT methods

### DIFF
--- a/.changeset/heavy-kings-add.md
+++ b/.changeset/heavy-kings-add.md
@@ -1,0 +1,22 @@
+---
+'@remote-ui/rpc': patch
+---
+
+Throw better errors on the RESULT and FUNCTION_RESULT methods
+
+```js
+case RESULT: {
+    const [callId, method] = data[1];
+
+    try {
+        callIdsToResolver.get(callId)!(...data[1]);
+        callIdsToResolver.delete(callId);
+    } catch (error) {
+        const {message} = error as Error;
+        throw new Error(
+        `Error in result listener. Method: ${method} Error: ${message}`,
+        );
+    }
+    break;
+}
+```

--- a/packages/rpc/src/endpoint.ts
+++ b/packages/rpc/src/endpoint.ts
@@ -203,10 +203,17 @@ export function createEndpoint<T>(
         break;
       }
       case RESULT: {
-        const [callId] = data[1];
+        const [callId, method] = data[1];
 
-        callIdsToResolver.get(callId)!(...data[1]);
-        callIdsToResolver.delete(callId);
+        try {
+          callIdsToResolver.get(callId)!(...data[1]);
+          callIdsToResolver.delete(callId);
+        } catch (error) {
+          const {message} = error as Error;
+          throw new Error(
+            `Error in result listener. Method: ${method} Error: ${message}`,
+          );
+        }
         break;
       }
       case RELEASE: {
@@ -215,10 +222,17 @@ export function createEndpoint<T>(
         break;
       }
       case FUNCTION_RESULT: {
-        const [callId] = data[1];
+        const [callId, method] = data[1];
 
-        callIdsToResolver.get(callId)!(...data[1]);
-        callIdsToResolver.delete(callId);
+        try {
+          callIdsToResolver.get(callId)!(...data[1]);
+          callIdsToResolver.delete(callId);
+        } catch (error) {
+          const {message} = error as Error;
+          throw new Error(
+            `Error in function result listener. Method: ${method} Error: ${message}`,
+          );
+        }
         break;
       }
       case FUNCTION_APPLY: {


### PR DESCRIPTION
### What
This PR improves error handling in the RPC endpoint by adding more contextual information when errors occur in the RESULT and FUNCTION_RESULT methods.

### Why
When errors occurred in result listeners, the original error messages lacked context about which method was being called, making debugging difficult. This change adds the method name to the error message, providing clearer information about where the failure occurred.

