### PR TITLE
expose hooks without side effect

### DIFF
--- a/.changeset/odd-wasps-fold.md
+++ b/.changeset/odd-wasps-fold.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/core': minor
+---
+
+Allow to import hooks without global window override side effect

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,11 +39,18 @@
       "require": "./build/cjs/html.cjs"
     },
     "./polyfill": {
-      "types": "./build/typescript/polyfill.d.ts",
-      "quilt:source": "./source/polyfill.ts",
-      "quilt:esnext": "./build/esnext/polyfill.esnext",
-      "import": "./build/esm/polyfill.mjs",
-      "require": "./build/cjs/polyfill.cjs"
+      "types": "./build/typescript/polyfill/polyfill.d.ts",
+      "quilt:source": "./source/polyfill/polyfill.ts",
+      "quilt:esnext": "./build/esnext/polyfill/polyfill.esnext",
+      "import": "./build/esm/polyfill/polyfill.mjs",
+      "require": "./build/cjs/polyfill/polyfill.cjs"
+    },
+    "./polyfill/hooks": {
+      "types": "./build/typescript/polyfill/hooks.d.ts",
+      "quilt:source": "./source/polyfill/hooks.ts",
+      "quilt:esnext": "./build/esnext/polyfill/hooks.esnext",
+      "import": "./build/esm/polyfill/hooks.mjs",
+      "require": "./build/cjs/polyfill/hooks.cjs"
     },
     "./receivers": {
       "types": "./build/typescript/receivers.d.ts",
@@ -63,7 +70,10 @@
         "./build/typescript/html.d.ts"
       ],
       "polyfill": [
-        "./build/typescript/polyfill.d.ts"
+        "./build/typescript/polyfill/polyfill.d.ts"
+      ],
+      "polyfill/hooks": [
+        "./build/typescript/polyfill/hooks.d.ts"
       ],
       "receivers": [
         "./build/typescript/receivers.d.ts"
@@ -71,7 +81,7 @@
     }
   },
   "sideEffects": [
-    "./source/polyfill.ts",
+    "./source/polyfill/polyfill.ts",
     "./build/cjs/polyfill.cjs",
     "./build/esm/polyfill.mjs",
     "./build/esnext/polyfill.esnext"

--- a/packages/core/source/elements/tests/connection.test.ts
+++ b/packages/core/source/elements/tests/connection.test.ts
@@ -1,4 +1,4 @@
-import '../../polyfill.ts';
+import '../../polyfill/polyfill.ts';
 
 import {describe, expect, it, vi, type MockedObject} from 'vitest';
 

--- a/packages/core/source/polyfill/hooks.ts
+++ b/packages/core/source/polyfill/hooks.ts
@@ -1,10 +1,11 @@
-import {Window, HOOKS, type Hooks} from '@remote-dom/polyfill';
+import {HOOKS, type Hooks} from '@remote-dom/polyfill';
 
 import {
   MUTATION_TYPE_INSERT_CHILD,
   MUTATION_TYPE_REMOVE_CHILD,
   MUTATION_TYPE_UPDATE_TEXT,
-} from './constants.ts';
+} from '../constants.ts';
+
 import {
   remoteId,
   remoteConnection,
@@ -12,12 +13,11 @@ import {
   disconnectRemoteNode,
   serializeRemoteNode,
   updateRemoteElementAttribute,
-} from './elements/internals.ts';
+} from '../elements/internals.ts';
 
-const window = new Window();
+import {window} from './window.ts';
+
 const hooks = window[HOOKS];
-
-Window.setGlobal(window);
 
 hooks.insertChild = (parent, node, index) => {
   const connection = remoteConnection(parent);
@@ -72,4 +72,4 @@ hooks.removeAttribute = (element, name) => {
   updateRemoteElementAttribute(element, name);
 };
 
-export {hooks, window, Window, type Hooks};
+export {hooks, type Hooks};

--- a/packages/core/source/polyfill/polyfill.ts
+++ b/packages/core/source/polyfill/polyfill.ts
@@ -1,0 +1,7 @@
+import {Window} from '@remote-dom/polyfill';
+import {window} from './window.ts';
+import {hooks, type Hooks} from './hooks.ts';
+
+Window.setGlobal(window);
+
+export {hooks, window, Window, type Hooks};

--- a/packages/core/source/polyfill/window.ts
+++ b/packages/core/source/polyfill/window.ts
@@ -1,0 +1,5 @@
+import {Window} from '@remote-dom/polyfill';
+
+const window = new Window();
+
+export {window};

--- a/packages/core/source/tests/elements.test.ts
+++ b/packages/core/source/tests/elements.test.ts
@@ -1,4 +1,4 @@
-import '../polyfill.ts';
+import '../polyfill/polyfill.ts';
 import {describe, it, expect, vi, type MockedObject} from 'vitest';
 
 import {

--- a/packages/core/source/tests/html.test.ts
+++ b/packages/core/source/tests/html.test.ts
@@ -1,4 +1,4 @@
-import '../polyfill.ts';
+import '../polyfill/polyfill.ts';
 import {describe, it, expect} from 'vitest';
 
 import {html, type PropertiesWithChildren} from '../html.ts';


### PR DESCRIPTION
Allows to import `hooks` from `core` without the `Window.setGlobal(window);` being executed allowing consumers when they and how they override globals.

It does that without introducing a breaking change.
We introduce a new `/polyfill/hooks` entry point which just returns the hooks.

Importing from `/polyfill/` will work just as before.


