### PR TITLE
Fix test events not writable

### DIFF
--- a/packages/polyfill/source/Event.ts
+++ b/packages/polyfill/source/Event.ts
@@ -117,9 +117,20 @@ export function fireEvent(
   if (!list) return;
 
   for (const listener of list) {
-    event.eventPhase =
-      event.target === currentTarget ? EventPhase.AT_TARGET : phase;
-    event.currentTarget = currentTarget;
+    // Safely set eventPhase property only if it's writable
+    try {
+      event.eventPhase =
+        event.target === currentTarget ? EventPhase.AT_TARGET : phase;
+    } catch {
+      // eventPhase property may be read-only on native DOM Events
+    }
+    
+    // Safely set currentTarget property only if it's writable
+    try {
+      event.currentTarget = currentTarget;
+    } catch {
+      // currentTarget property may be read-only on native DOM Events
+    }
 
     try {
       if (typeof listener === 'object') {

--- a/packages/polyfill/source/EventTarget.ts
+++ b/packages/polyfill/source/EventTarget.ts
@@ -109,8 +109,19 @@ export class EventTarget {
     // while (target instanceof Node && (target = target.parentNode)) {
     //   path.push(target);
     // }
-    event.target = this;
-    event.srcElement = this;
+    // Safely set target property only if it's writable (native DOM Events have read-only target)
+    try {
+      event.target = this;
+    } catch {
+      // target property is read-only on native DOM Events, which is fine
+      // since the native event already has the correct target
+    }
+    
+    try {
+      event.srcElement = this;
+    } catch {
+      // srcElement property may also be read-only on some implementations
+    }
     event[PATH] = path;
 
     for (let i = path.length; i--; ) {


### PR DESCRIPTION
### Problem

Changes were made to custom elements in checkout to use dispatchEvent https://github.com/shop/world/pull/93582 and standard DOM Events.

The issue is that these Event objects are not writable as seen here https://buildkite.com/shopify/world-customer-account-web/builds/7118#019856f2-f465-43d3-88a4-154545292a72

```
Error: Uncaught [TypeError: Cannot set property target of [object Event] which has only a getter]
```

Coming from remote-dom/polyfill

I asked Claude code to explain why this is happening in our test environment and here's the explanation

The issue occurs because of a mismatch between two different Event implementations:

  1. Native DOM Events (created by userEvent.click() in tests): These have
  read-only properties like target, currentTarget, and eventPhase as defined by
   the DOM specification.

  2. Polyfilled Events (from remote-dom): These define these properties as
  writable (like target: EventTarget | null = null on line 41).

  When your tests run userEvent.click(), it creates a native DOM Event object,
  but then the remote-dom polyfill's dispatchEvent method tries to modify
  properties on that native event as if it were a polyfilled event.

  The DOM specification defines these properties as read-only getters:

  - Event.target - read-only, set when the event is dispatched
  - Event.currentTarget - read-only, changes as event bubbles through DOM
  - Event.eventPhase - read-only, indicates capture/target/bubble phase

  So when the polyfill code tried to do:
  event.target = this;           // ❌ TypeError: Cannot set property target
  event.currentTarget = currentTarget; // ❌ TypeError: Cannot set property 
  currentTarget  
  event.eventPhase = phase;      // ❌ TypeError: Cannot set property 
  eventPhase

   it failed because these are read-only on native events.

  The try-catch blocks now allow the polyfill to work with both types of events
   - it will set the properties on polyfilled events (where they're writable)
  and gracefully skip setting them on native events (where they're already
  correctly set by the browser).