### PR TITLE
transferables for encoder

### DIFF
--- a/packages/rpc/src/encoding/basic.ts
+++ b/packages/rpc/src/encoding/basic.ts
@@ -132,6 +132,13 @@ export function createBasicEncoder(api: EncodingStrategyApi): EncodingStrategy {
       return result;
     }
 
+    if (isTransferable(value)) {
+      const result: EncodeResult = [value, [value]];
+      seen.set(value, result);
+
+      return result;
+    }
+
     const result: EncodeResult = [value];
     seen.set(value, result);
 
@@ -218,4 +225,14 @@ export function createBasicEncoder(api: EncodingStrategyApi): EncodingStrategy {
 
     return value as any;
   }
+}
+
+function isTransferable(value: unknown): value is Transferable {
+  if (value instanceof ArrayBuffer) return true;
+  if (value instanceof MessagePort) return true;
+  if (value instanceof ReadableStream) return true;
+  if (value instanceof WritableStream) return true;
+  if (value instanceof TransformStream) return true;
+
+  return false;
 }


### PR DESCRIPTION
implementing a subset of widely available transferable objects ([MDN Link](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Transferable_objects#supported_objects)) for RPC's basic encoder.