### PR TITLE
fix error events not working

### DIFF
--- a/.changeset/nasty-spoons-wonder.md
+++ b/.changeset/nasty-spoons-wonder.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/polyfill': patch
+---
+
+fix error events not working

--- a/packages/polyfill/source/ErrorEvent.ts
+++ b/packages/polyfill/source/ErrorEvent.ts
@@ -1,0 +1,20 @@
+import {Event} from './Event.ts';
+
+// https://html.spec.whatwg.org/multipage/webappapis.html#errorevent
+export class ErrorEvent extends Event {
+  readonly message: ErrorEventInit['message'];
+  readonly filename: ErrorEventInit['filename'];
+  readonly lineno: ErrorEventInit['lineno'];
+  readonly colno: ErrorEventInit['colno'];
+  readonly error: ErrorEventInit['error'];
+
+  constructor(type: string, eventInitDict: ErrorEventInit) {
+    super(type, eventInitDict);
+
+    this.message = eventInitDict.message;
+    this.filename = eventInitDict.filename;
+    this.lineno = eventInitDict.lineno;
+    this.colno = eventInitDict.colno;
+    this.error = eventInitDict.error;
+  }
+}

--- a/packages/polyfill/source/PromiseRejectionEvent.ts
+++ b/packages/polyfill/source/PromiseRejectionEvent.ts
@@ -1,0 +1,14 @@
+import {Event} from './Event.ts';
+
+//https://html.spec.whatwg.org/multipage/webappapis.html#promiserejectionevent
+export class PromiseRejectionEvent extends Event {
+  readonly promise: PromiseRejectionEventInit['promise'];
+  readonly reason: PromiseRejectionEventInit['reason'];
+
+  constructor(type: string, eventInitDict: PromiseRejectionEventInit) {
+    super(type, eventInitDict);
+
+    this.promise = eventInitDict.promise;
+    this.reason = eventInitDict.reason;
+  }
+}

--- a/packages/polyfill/source/tests/global-errors.test.ts
+++ b/packages/polyfill/source/tests/global-errors.test.ts
@@ -1,0 +1,149 @@
+import {ErrorEvent} from '../ErrorEvent.ts';
+import {PromiseRejectionEvent} from '../PromiseRejectionEvent.ts';
+import {Window} from '../Window.ts';
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+
+describe('global errors', () => {
+  describe('onerror', () => {
+    let originalOnerror: any;
+
+    beforeEach(() => {
+      originalOnerror = globalThis.onerror;
+    });
+
+    afterEach(() => {
+      globalThis.onerror = originalOnerror;
+    });
+
+    it('sets onerror handler on window instance', () => {
+      const handler = vi.fn();
+      const window = new Window();
+
+      window.onerror = handler;
+      expect(window.onerror).toBe(handler);
+    });
+
+    it('overrides onerror handler on window instance', () => {
+      const handler = vi.fn();
+      const handler2 = vi.fn();
+
+      const window = new Window();
+      window.onerror = handler;
+      window.onerror = handler2;
+
+      expect(window.onerror).toBe(handler2);
+    });
+
+    it('calls handler when error occurs', () => {
+      const handler = vi.fn();
+      const window = new Window();
+
+      const error = new Error('test');
+
+      window.onerror = handler;
+      window.dispatchEvent(
+        new ErrorEvent('error', {
+          error,
+          filename: 'test.ts',
+          lineno: 1,
+          colno: 1,
+        }),
+      );
+
+      expect(handler).toHaveBeenCalledWith('Error', 'test.ts', 1, 1, error);
+    });
+
+    it('allows null assignment', () => {
+      const handler = vi.fn();
+      const window = new Window();
+      window.onerror = handler;
+      expect(window.onerror).toBe(handler);
+
+      window.onerror = null;
+      expect(window.onerror).toBe(null);
+    });
+
+    it('works when window is set as global', () => {
+      const window = new Window();
+      Window.setGlobalThis(window);
+      const handler = vi.fn();
+      window.onerror = handler;
+
+      expect(window.onerror).toBe(handler);
+    });
+  });
+
+  describe('onunhandledrejection', () => {
+    let originalOnunhandledrejection: any;
+
+    beforeEach(() => {
+      originalOnunhandledrejection = globalThis.onunhandledrejection;
+    });
+
+    afterEach(() => {
+      globalThis.onunhandledrejection = originalOnunhandledrejection;
+    });
+
+    it('sets onunhandledrejection handler on window instance', () => {
+      const handler = vi.fn();
+      const window = new Window();
+
+      window.onunhandledrejection = handler;
+      expect(window.onunhandledrejection).toBe(handler);
+    });
+
+    it('overrides onunhandledrejection handler on window instance', () => {
+      const handler = vi.fn();
+      const handler2 = vi.fn();
+      const window = new Window();
+
+      window.onunhandledrejection = handler;
+      window.onunhandledrejection = handler2;
+      expect(window.onunhandledrejection).toBe(handler2);
+    });
+
+    it('calls handler when unhandled rejection occurs', () => {
+      const handler = vi.fn();
+      const window = new Window();
+      window.onunhandledrejection = handler;
+
+      const error = new Error('test');
+      const promise = Promise.resolve();
+
+      window.dispatchEvent(
+        new PromiseRejectionEvent('unhandledrejection', {
+          promise: promise,
+          reason: error,
+        }),
+      );
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          promise,
+          reason: error,
+        }),
+      );
+
+      expect(handler).toHaveBeenCalledWith(expect.any(PromiseRejectionEvent));
+    });
+
+    it('allows null assignment', () => {
+      const handler = vi.fn();
+      const window = new Window();
+      window.onunhandledrejection = handler;
+      expect(window.onunhandledrejection).toBe(handler);
+
+      window.onunhandledrejection = null;
+      expect(window.onunhandledrejection).toBe(null);
+    });
+
+    it('works when window is set as global', () => {
+      const window = new Window();
+      Window.setGlobalThis(window);
+      const handler = vi.fn();
+      window.onunhandledrejection = handler;
+
+      expect(window.onunhandledrejection).toBe(handler);
+    });
+  });
+});


### PR DESCRIPTION
In polyfilled environments that use realms, it's currently not possible to listen to global errors and unhandled rejections. 


## `onerror` / `onunhandledrejection` handlers

e.g.
```js
window.onerror = (...args) => {
  console.log('### ERROR', args)
};

globalThis.onerror = (...args) => {
  console.log('### ERROR', args)
};
```

the following works btw. but is not exhaustive enough because libs like sentry and bugsnag attach themselves to `window` or `globalThis`
```js
onerror = (...args) => {
  console.log('### ERROR', args)
};
```

We now make this work by adding event listeners for those events the polyfill `window` instance that just forwards it to the `onerror` / `onunhandledrejection` functions. (thanks @igor10k for that idea!). Those events have been available for years so I think that's ok.

This also doesn't work at the moment inside extensions:

```js
globalThis.addEventListener("error", (...args) => {
  console.log('### ERROR', args);
});
```

This doesn't work because in realms the `globalThis.addEventListener` is *not* the one the worker is dispatching error events to. So we need to to dispatch those events manually from the worker to the realm global. 
However we can't dispatch the native event because the polyfill dispatchEvent implementation tries to override `target` on the event instance, which throws for native events.  So we need to also polyfill `ErrorEvent` and `PromiseRejectionEvent` which can be dispatched