### PR TITLE
Fix insertBefore leaving the previous sibling pointing past the inserted node

### DIFF
--- a/.changeset/polyfill-insert-before-sibling-chain.md
+++ b/.changeset/polyfill-insert-before-sibling-chain.md
@@ -1,0 +1,11 @@
+---
+'@remote-dom/polyfill': patch
+---
+
+Fix `insertBefore()` leaving the previous sibling pointing past the inserted node
+
+`ParentNode.insertBefore()` relinked the new child's `NEXT`/`PREV` and the reference node's `PREV`, but only repointed the previous sibling's `NEXT` when the reference node was the first child. Inserting before any _later_ child therefore left the forward sibling chain skipping the new node.
+
+That chain is what `querySelector()`, `querySelectorAll()`, and `firstChild`/`nextSibling` traversal walk, so an affected node was unreachable from every selector query and sibling walk — while `childNodes`, `parentNode`, `previousSibling`, and the host mirror all still reported it as present. The node rendered correctly on the host and was invisible to the remote environment's own lookups, with no error raised. `replaceChild()`, `prepend()` (of more than one node), and `ChildNode.after()` all route through the same branch and were affected too.
+
+This is easy to hit whenever a framework renders ahead of existing content — for example inserting content before an already-appended `<style>` element — where it silently breaks code as ordinary as `document.querySelector('#my-modal').showModal()`.

--- a/packages/polyfill/source/ParentNode.ts
+++ b/packages/polyfill/source/ParentNode.ts
@@ -121,9 +121,11 @@ export class ParentNode extends ChildNode {
       if (before.parentNode !== this) {
         throw Error('reference node is not a child of this parent');
       }
+      const prev = before[PREV];
       child[NEXT] = before;
-      child[PREV] = before[PREV];
-      if (before[PREV] === null) this[CHILD] = child;
+      child[PREV] = prev;
+      if (prev === null) this[CHILD] = child;
+      else prev[NEXT] = child;
       before[PREV] = child;
     } else {
       child[NEXT] = null;

--- a/packages/polyfill/source/tests/ParentNode.test.ts
+++ b/packages/polyfill/source/tests/ParentNode.test.ts
@@ -1,0 +1,189 @@
+import {Window} from '../index.ts';
+
+import {describe, it, expect, beforeEach} from 'vitest';
+
+/**
+ * Walks the forward sibling chain, the traversal selector queries recurse
+ * through. It is stored independently of `childNodes`, so the two can disagree.
+ */
+function siblingChain(parent: ParentNode) {
+  const names: string[] = [];
+  for (let node = parent.firstChild; node; node = node.nextSibling) {
+    names.push(node.nodeName.toLowerCase());
+  }
+  return names;
+}
+
+function childNodeNames(parent: ParentNode) {
+  return Array.from(parent.childNodes, (node) => node.nodeName.toLowerCase());
+}
+
+describe('ParentNode child list', () => {
+  beforeEach(() => {
+    const window = new Window();
+    Window.setGlobalThis(window);
+  });
+
+  describe('insertBefore', () => {
+    it('links the previous sibling to a node inserted before a non-first child', () => {
+      const first = document.createElement('first-child');
+      const last = document.createElement('last-child');
+      document.body.append(first, last);
+
+      const inserted = document.createElement('inserted-child');
+      document.body.insertBefore(inserted, last);
+
+      expect(siblingChain(document.body)).toStrictEqual([
+        'first-child',
+        'inserted-child',
+        'last-child',
+      ]);
+      expect(first.nextSibling).toBe(inserted);
+      expect(inserted.previousSibling).toBe(first);
+    });
+
+    it('inserts before the first child', () => {
+      const existing = document.createElement('existing-child');
+      document.body.appendChild(existing);
+
+      const inserted = document.createElement('inserted-child');
+      document.body.insertBefore(inserted, existing);
+
+      expect(siblingChain(document.body)).toStrictEqual([
+        'inserted-child',
+        'existing-child',
+      ]);
+      expect(document.body.firstChild).toBe(inserted);
+    });
+
+    it('keeps the sibling chain and childNodes in agreement', () => {
+      const anchor = document.createElement('anchor-child');
+      document.body.appendChild(anchor);
+
+      for (let i = 0; i < 3; i++) {
+        document.body.insertBefore(
+          document.createElement(`child-${i}`),
+          anchor,
+        );
+      }
+
+      expect(siblingChain(document.body)).toStrictEqual(
+        childNodeNames(document.body),
+      );
+      expect(siblingChain(document.body)).toStrictEqual([
+        'child-0',
+        'child-1',
+        'child-2',
+        'anchor-child',
+      ]);
+    });
+
+    it('finds a node inserted before a non-first child by selector', () => {
+      const style = document.createElement('style');
+      document.body.appendChild(style);
+
+      const modal = document.createElement('s-modal');
+      modal.setAttribute('id', 'add-zone');
+      document.body.insertBefore(modal, style);
+
+      expect(document.querySelector('s-modal#add-zone')).toBe(modal);
+      expect(document.querySelectorAll('s-modal')).toHaveLength(1);
+    });
+
+    it('inserts the children of a document fragment in order', () => {
+      const anchor = document.createElement('anchor-child');
+      document.body.appendChild(anchor);
+
+      const fragment = document.createDocumentFragment();
+      fragment.append(
+        document.createElement('fragment-first'),
+        document.createElement('fragment-last'),
+      );
+      document.body.insertBefore(fragment, anchor);
+
+      expect(siblingChain(document.body)).toStrictEqual([
+        'fragment-first',
+        'fragment-last',
+        'anchor-child',
+      ]);
+      expect(siblingChain(document.body)).toStrictEqual(
+        childNodeNames(document.body),
+      );
+    });
+
+    it('relinks a node moved from later to earlier in the same parent', () => {
+      const first = document.createElement('first-child');
+      const middle = document.createElement('middle-child');
+      const last = document.createElement('last-child');
+      document.body.append(first, middle, last);
+
+      document.body.insertBefore(last, middle);
+
+      expect(siblingChain(document.body)).toStrictEqual([
+        'first-child',
+        'last-child',
+        'middle-child',
+      ]);
+      expect(siblingChain(document.body)).toStrictEqual(
+        childNodeNames(document.body),
+      );
+    });
+  });
+
+  describe('replaceChild', () => {
+    it('keeps the chain walkable after replacing a middle child', () => {
+      const first = document.createElement('first-child');
+      const placeholder = document.createElement('placeholder-child');
+      const last = document.createElement('last-child');
+      document.body.append(first, placeholder, last);
+
+      const replacement = document.createElement('replacement-child');
+      document.body.replaceChild(replacement, placeholder);
+
+      expect(siblingChain(document.body)).toStrictEqual([
+        'first-child',
+        'replacement-child',
+        'last-child',
+      ]);
+      expect(document.querySelector('replacement-child')).toBe(replacement);
+      expect(document.querySelector('placeholder-child')).toBeNull();
+    });
+  });
+
+  describe('prepend', () => {
+    it('prepends multiple nodes ahead of an existing child', () => {
+      const existing = document.createElement('existing-child');
+      document.body.appendChild(existing);
+
+      document.body.prepend(
+        document.createElement('prepended-first'),
+        document.createElement('prepended-last'),
+      );
+
+      expect(siblingChain(document.body)).toStrictEqual([
+        'prepended-first',
+        'prepended-last',
+        'existing-child',
+      ]);
+      expect(siblingChain(document.body)).toStrictEqual(
+        childNodeNames(document.body),
+      );
+    });
+  });
+
+  describe('ChildNode.after', () => {
+    it('inserts after a non-last child', () => {
+      const first = document.createElement('first-child');
+      const last = document.createElement('last-child');
+      document.body.append(first, last);
+
+      first.after(document.createElement('inserted-child'));
+
+      expect(siblingChain(document.body)).toStrictEqual([
+        'first-child',
+        'inserted-child',
+        'last-child',
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## The bug

`ParentNode.insertInto(child, before)` relinks the new child's `NEXT`/`PREV` and the reference node's `PREV`, but only repoints the **previous sibling's `NEXT`** when the reference node is the first child:

```js
if (before) {
  child[NEXT] = before;
  child[PREV] = before[PREV];
  if (before[PREV] === null) this[CHILD] = child;  // only insert-at-front is handled
  before[PREV] = child;                            // missing: else child[PREV][NEXT] = child
}
```

Insert before any *later* child and the forward sibling chain skips the new node.

That chain is exactly what `querySelector` / `querySelectorAll` recurse through (`within[CHILD]`, then `[CHILD]` / `[NEXT]`), and what `firstChild` + `nextSibling` traversal walks. So an affected node becomes unreachable from every selector query and sibling walk — while `childNodes` (a spliced array), `parentNode`, `previousSibling`, `isConnected`, and the host mirror (built from the `insertChild(parent, child, index)` hook) all still report it as present.

The node renders correctly on the host and is invisible to the remote environment's own lookups, with **no error raised**. `replaceChild` (`removeChild` + `insertInto(new, next)`), `prepend` of more than one node, and `ChildNode.after` on a non-last child all route through the same branch and were affected too.

The divergence, on `main`, from a hand-rolled host mirror fed by the real `insertChild` hook:

| | sandbox chain | host mirror | `querySelector('s-modal')` |
|---|---|---|---|
| before | `[s-page, style]` ❌ | `[s-page, s-modal, style]` | `null` ❌ |
| after | `[s-page, s-modal, style]` ✅ | `[s-page, s-modal, style]` | `s-modal` ✅ |
