### PR TITLE
Add getElementsByClassName to the DOM polyfill

### DIFF
--- a/.changeset/fuzzy-classes-find.md
+++ b/.changeset/fuzzy-classes-find.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/polyfill': minor
+---
+
+Add `getElementsByClassName()` to polyfilled documents and elements.

--- a/packages/polyfill/source/Document.ts
+++ b/packages/polyfill/source/Document.ts
@@ -9,6 +9,7 @@ import {
 } from './constants.ts';
 import type {Window} from './Window.ts';
 import type {Node} from './Node.ts';
+import {getElementsByClassName as findElementsByClassName} from './getElementsByClassName.ts';
 import {Event} from './Event.ts';
 import {ParentNode} from './ParentNode.ts';
 import {Element} from './Element.ts';
@@ -42,6 +43,10 @@ export class Document extends ParentNode {
     this.appendChild(this.documentElement);
     this.documentElement.appendChild(this.head);
     this.documentElement.appendChild(this.body);
+  }
+
+  getElementsByClassName(classNames: string) {
+    return findElementsByClassName(this, classNames);
   }
 
   createElement(localName: string) {

--- a/packages/polyfill/source/Element.ts
+++ b/packages/polyfill/source/Element.ts
@@ -1,5 +1,6 @@
 import {NS, ATTRIBUTES, NamespaceURI, NodeType} from './constants.ts';
 import {ParentNode} from './ParentNode.ts';
+import {getElementsByClassName as findElementsByClassName} from './getElementsByClassName.ts';
 import {NamedNodeMap} from './NamedNodeMap.ts';
 import {Attr} from './Attr.ts';
 import {serializeNode, serializeChildren, parseHtml} from './serialization.ts';
@@ -49,6 +50,10 @@ export class Element extends ParentNode {
 
   get firstElementChild() {
     return this.children[0] ?? null;
+  }
+
+  getElementsByClassName(classNames: string) {
+    return findElementsByClassName(this, classNames);
   }
 
   get lastElementChild() {

--- a/packages/polyfill/source/getElementsByClassName.ts
+++ b/packages/polyfill/source/getElementsByClassName.ts
@@ -1,0 +1,26 @@
+import type {ParentNode} from './ParentNode.ts';
+import {NodeList} from './NodeList.ts';
+import {descendants, isElementNode} from './shared.ts';
+
+export function getElementsByClassName(node: ParentNode, classNames: string) {
+  const names = [...new Set(String(classNames).split(/[\t\n\f\r ]+/))].filter(
+    Boolean,
+  );
+  const matches = new NodeList();
+
+  if (names.length === 0) return matches;
+
+  for (const descendant of descendants(node)) {
+    if (!isElementNode(descendant)) continue;
+
+    const classes = descendant.getAttribute('class');
+    if (classes == null) continue;
+
+    const tokens = classes.split(/[\t\n\f\r ]+/);
+    if (names.every((name) => tokens.includes(name))) {
+      matches.push(descendant);
+    }
+  }
+
+  return matches;
+}

--- a/packages/polyfill/source/tests/getElementsByClassName.test.ts
+++ b/packages/polyfill/source/tests/getElementsByClassName.test.ts
@@ -1,0 +1,75 @@
+import {beforeEach, describe, expect, it} from 'vitest';
+
+import {NodeList} from '../NodeList.ts';
+import {Window} from '../Window.ts';
+import type {Element} from '../Element.ts';
+
+describe('getElementsByClassName', () => {
+  let window: Window;
+
+  beforeEach(() => {
+    window = new Window();
+  });
+
+  it('is exposed on Document and Element but not DocumentFragment', () => {
+    expect(window.document.getElementsByClassName).toBeTypeOf('function');
+    expect(window.document.body.getElementsByClassName).toBeTypeOf('function');
+    expect(
+      (window.document.createDocumentFragment() as any).getElementsByClassName,
+    ).toBeUndefined();
+  });
+
+  it('finds descendants containing every requested class in tree order', () => {
+    window.document.body.innerHTML = `
+      <main class="card selected">
+        <div class="selected card first"></div>
+        <section><span class="card selected last"></span></section>
+        <div class="card"></div>
+      </main>
+    `;
+
+    const matches = window.document.getElementsByClassName('card selected');
+    const withinMain = matches[0]!.getElementsByClassName('selected card');
+
+    expect(matches.map((element: Element) => element.localName)).toEqual([
+      'main',
+      'div',
+      'span',
+    ]);
+    expect(withinMain.map((element: Element) => element.localName)).toEqual([
+      'div',
+      'span',
+    ]);
+  });
+
+  it('treats class names literally instead of parsing a selector', () => {
+    const element = window.document.createElement('div');
+    element.setAttribute('class', 'has.dot has:colon');
+    window.document.body.appendChild(element);
+
+    expect(window.document.getElementsByClassName('has.dot')[0]).toBe(element);
+    expect(window.document.getElementsByClassName('has:colon')[0]).toBe(
+      element,
+    );
+  });
+
+  it('uses ASCII whitespace, removes duplicate names, and handles empty input', () => {
+    const element = window.document.createElement('div');
+    element.setAttribute('class', 'one\ttwo\nthree');
+    window.document.body.appendChild(element);
+
+    expect(window.document.getElementsByClassName(' one one\ttwo ')[0]).toBe(
+      element,
+    );
+    expect(window.document.getElementsByClassName('   ')).toHaveLength(0);
+  });
+
+  it('returns the polyfill collection with item() access', () => {
+    window.document.body.innerHTML = '<div class="match"></div>';
+
+    const matches = window.document.getElementsByClassName('match');
+
+    expect(matches).toBeInstanceOf(NodeList);
+    expect(matches.item(0)).toBe(matches[0]);
+  });
+});


### PR DESCRIPTION
## What changed

Remote code is commonly type-checked against `lib.dom`, but `document.getElementsByClassName()` and `element.getElementsByClassName()` are missing at runtime from `@remote-dom/polyfill`. This adds both standard hosts (deliberately not `DocumentFragment`) and returns matches in tree order.

The lookup tokenizes ASCII whitespace, requires every requested class, removes duplicate search tokens, and compares class names literally. It does not build a CSS selector, so class names containing selector punctuation such as `.` and `:` work correctly.

The returned value follows the polyfill's existing concrete `NodeList` collection model. Live `HTMLCollection` behavior remains a separate compatibility concern, as it does in #620.

## Validation

- `pnpm exec vitest run` (179 tests)
- `pnpm lint`
- `pnpm type-check`
- `mise exec node@20.20.0 -- pnpm --filter @remote-dom/polyfill build`
