### PR TITLE
Forward focus and scrollIntoView to the host

### DIFF
--- a/.changeset/tidy-elements-act.md
+++ b/.changeset/tidy-elements-act.md
@@ -1,0 +1,6 @@
+---
+'@remote-dom/core': minor
+'@remote-dom/polyfill': minor
+---
+
+Forward polyfilled `Element.focus()` and `Element.scrollIntoView()` calls to their host implementations.

--- a/packages/core/source/polyfill/hooks.ts
+++ b/packages/core/source/polyfill/hooks.ts
@@ -72,4 +72,11 @@ hooks.removeAttribute = (element, name) => {
   updateRemoteElementAttribute(element, name);
 };
 
+hooks.callMethod = (element, method, ...args) => {
+  const connection = remoteConnection(element);
+  if (connection == null) return;
+
+  connection.call(remoteId(element), method, ...args);
+};
+
 export {hooks, type Hooks};

--- a/packages/core/source/tests/imperative-methods.test.ts
+++ b/packages/core/source/tests/imperative-methods.test.ts
@@ -1,0 +1,41 @@
+import '../polyfill/polyfill.ts';
+
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {RemoteRootElement} from '../elements/RemoteRootElement.ts';
+import {RemoteReceiver} from '../receivers/RemoteReceiver.ts';
+
+customElements.define('imperative-method-root', RemoteRootElement);
+
+describe('polyfilled imperative element methods', () => {
+  let receiver: RemoteReceiver;
+  let root: RemoteRootElement;
+
+  beforeEach(() => {
+    receiver = new RemoteReceiver();
+    root = document.createElement(
+      'imperative-method-root',
+    ) as RemoteRootElement;
+    root.connect(receiver.connection);
+  });
+
+  it('calls focus() and scrollIntoView() on the host implementation', () => {
+    const element = document.createElement('div');
+    root.appendChild(element);
+
+    const received = receiver.root.children[0]!;
+    const implementation = {
+      focus: vi.fn(),
+      scrollIntoView: vi.fn(),
+    };
+    receiver.implement(received, implementation);
+
+    const focusOptions = {preventScroll: true};
+    const scrollOptions = {behavior: 'smooth'} as const;
+    element.focus(focusOptions);
+    element.scrollIntoView(scrollOptions);
+
+    expect(implementation.focus).toHaveBeenCalledWith(focusOptions);
+    expect(implementation.scrollIntoView).toHaveBeenCalledWith(scrollOptions);
+  });
+});

--- a/packages/polyfill/source/Element.ts
+++ b/packages/polyfill/source/Element.ts
@@ -1,6 +1,7 @@
 import {
   NS,
   ATTRIBUTES,
+  HOOKS,
   HTML_NAMESPACE,
   NODE_TYPE_ELEMENT,
   type NamespaceURI,
@@ -87,20 +88,12 @@ export class Element extends ParentNode {
     return sib;
   }
 
-  focus(options?: FocusOptions) {
-    if (options === undefined) {
-      this.callHostMethod('focus');
-    } else {
-      this.callHostMethod('focus', options);
-    }
+  focus(...args: [options?: FocusOptions]) {
+    this[HOOKS].callMethod?.(this as any, 'focus', ...args);
   }
 
-  scrollIntoView(arg?: boolean | ScrollIntoViewOptions) {
-    if (arg === undefined) {
-      this.callHostMethod('scrollIntoView');
-    } else {
-      this.callHostMethod('scrollIntoView', arg);
-    }
+  scrollIntoView(...args: [arg?: boolean | ScrollIntoViewOptions]) {
+    this[HOOKS].callMethod?.(this as any, 'scrollIntoView', ...args);
   }
 
   setAttribute(name: string, value: string) {

--- a/packages/polyfill/source/Element.ts
+++ b/packages/polyfill/source/Element.ts
@@ -87,6 +87,22 @@ export class Element extends ParentNode {
     return sib;
   }
 
+  focus(options?: FocusOptions) {
+    if (options === undefined) {
+      this.callHostMethod('focus');
+    } else {
+      this.callHostMethod('focus', options);
+    }
+  }
+
+  scrollIntoView(arg?: boolean | ScrollIntoViewOptions) {
+    if (arg === undefined) {
+      this.callHostMethod('scrollIntoView');
+    } else {
+      this.callHostMethod('scrollIntoView', arg);
+    }
+  }
+
   setAttribute(name: string, value: string) {
     this.attributes.setNamedItem(new Attr(name, String(value)));
   }

--- a/packages/polyfill/source/Node.ts
+++ b/packages/polyfill/source/Node.ts
@@ -37,10 +37,6 @@ export class Node extends EventTarget {
     return this[OWNER_DOCUMENT].defaultView[HOOKS];
   }
 
-  protected callHostMethod(method: string, ...args: unknown[]) {
-    this[HOOKS].callMethod?.(this as any, method, ...args);
-  }
-
   get localName() {
     return this[NAME];
   }

--- a/packages/polyfill/source/Node.ts
+++ b/packages/polyfill/source/Node.ts
@@ -37,6 +37,10 @@ export class Node extends EventTarget {
     return this[OWNER_DOCUMENT].defaultView[HOOKS];
   }
 
+  protected callHostMethod(method: string, ...args: unknown[]) {
+    this[HOOKS].callMethod?.(this as any, method, ...args);
+  }
+
   get localName() {
     return this[NAME];
   }

--- a/packages/polyfill/source/hooks.ts
+++ b/packages/polyfill/source/hooks.ts
@@ -23,4 +23,5 @@ export interface Hooks {
     listener: EventListenerOrEventListenerObject | null,
     options?: boolean | EventListenerOptions,
   ): void;
+  callMethod(element: Element, method: string, ...args: unknown[]): unknown;
 }

--- a/packages/polyfill/source/tests/ElementMethods.test.ts
+++ b/packages/polyfill/source/tests/ElementMethods.test.ts
@@ -1,0 +1,59 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {HOOKS} from '../constants.ts';
+import {Window} from '../Window.ts';
+
+describe('imperative element methods', () => {
+  let window: Window;
+  const callMethod = vi.fn();
+
+  beforeEach(() => {
+    window = new Window();
+    window[HOOKS] = {callMethod};
+    callMethod.mockClear();
+  });
+
+  it('forwards focus() through the window hook', () => {
+    const element = window.document.createElement('div');
+    const options = {preventScroll: true};
+
+    element.focus();
+    element.focus(options);
+
+    expect(callMethod).toHaveBeenNthCalledWith(1, element, 'focus');
+    expect(callMethod).toHaveBeenNthCalledWith(2, element, 'focus', options);
+  });
+
+  it('forwards scrollIntoView() through the window hook', () => {
+    const element = window.document.createElement('div');
+    const options = {behavior: 'smooth'} as const;
+
+    element.scrollIntoView();
+    element.scrollIntoView(false);
+    element.scrollIntoView(options);
+
+    expect(callMethod).toHaveBeenNthCalledWith(1, element, 'scrollIntoView');
+    expect(callMethod).toHaveBeenNthCalledWith(
+      2,
+      element,
+      'scrollIntoView',
+      false,
+    );
+    expect(callMethod).toHaveBeenNthCalledWith(
+      3,
+      element,
+      'scrollIntoView',
+      options,
+    );
+  });
+
+  it('is a no-op when no host method hook is installed', () => {
+    const standaloneWindow = new Window();
+    const element = standaloneWindow.document.createElement('div');
+
+    expect(() => {
+      element.focus();
+      element.scrollIntoView();
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What changed

`focus()` and `scrollIntoView()` are missing from polyfilled elements, even though Remote DOM already has a method-call channel and both operations can be performed by the rendered host element. Remote code type-checked against `lib.dom` therefore fails at runtime before it can use that channel.

This adds a general imperative-method hook to `@remote-dom/polyfill`, implements `focus()` and `scrollIntoView()` on the polyfill's shared `Element` abstraction, and wires the core polyfill hook to the connected `RemoteConnection`. Options are forwarded unchanged. Standalone or disconnected polyfilled elements keep browser-like no-op behavior when no host hook is available.

The core regression test connects a real `RemoteRootElement` and `RemoteReceiver`, registers the host implementation, and verifies both method calls end to end.

These methods live on the shared `Element` class because that is the current concrete class returned for ordinary and custom HTML elements on `main`. #626 separately proposes concrete HTML constructor identity.

`getBoundingClientRect()` is deliberately not included: it is synchronous and returns host layout data, which cannot be faithfully implemented over an asynchronous remote connection.

## Validation

- `pnpm exec vitest run` (178 tests)
- `pnpm lint`
- `pnpm type-check`
- `mise exec node@20.20.0 -- pnpm --filter @remote-dom/polyfill --filter @remote-dom/core build`
