### PR TITLE
Harden GitHub Actions dependencies and permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    cooldown:
+      default-days: 7
     groups:
       github-actions-minor-patch:
         applies-to: version-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,10 +44,15 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      github-actions-minor-patch:
+      github-actions:
         applies-to: version-updates
         patterns:
           - '*'
         update-types:
+          - 'major'
           - 'minor'
           - 'patch'
+    ignore:
+      - dependency-name: 'changesets/action'
+        update-types:
+          - 'version-update:semver-major'

--- a/.github/workflows/actions/prepare/action.yml
+++ b/.github/workflows/actions/prepare/action.yml
@@ -3,8 +3,8 @@ description: Set up Node.js and pnpm, then install repository dependencies
 runs:
   using: 'composite'
   steps:
-    - uses: pnpm/action-setup@e9540b3eafaf84907c087a645d3258bfaa861427 # v3.0.0
-    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+    - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         cache: pnpm
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/changesets-reminder.yml
+++ b/.github/workflows/changesets-reminder.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 5
     if: ${{ !github.event.pull_request.draft && !startsWith(github.head_ref, 'changeset-release/') }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: mskelton/changelog-reminder-action@41fc0852a6e00fc4506a5d7b8a4178062743133a # v3.0.0
         with:
           changelogRegex: "\\.changeset"

--- a/.github/workflows/changesets-reminder.yml
+++ b/.github/workflows/changesets-reminder.yml
@@ -9,14 +9,21 @@ on:
       - '!*.test.*'
       - '!*.md'
 
+permissions: {}
+
 jobs:
   remind:
     name: Changeset Reminder
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
     if: ${{ !github.event.pull_request.draft && !startsWith(github.head_ref, 'changeset-release/') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: mskelton/changelog-reminder-action@41fc0852a6e00fc4506a5d7b8a4178062743133a # v3.0.0
         with:
           changelogRegex: "\\.changeset"

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -26,6 +26,7 @@ jobs:
       # @see https://github.com/changesets/action
       - uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
+          # The default GITHUB_TOKEN cannot trigger workflows from release-PR commits.
           github-token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
           title: 'Publish packages 🚀'
           commit: 'Publish packages'

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -12,20 +12,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
-          # This (plus the GITHUB_TOKEN on the changeset action) allow other workflows to run on the PR that changesets creates.
+          # This (plus the github-token input on the Changesets action) allows other workflows to run on the PR that Changesets creates.
           token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
 
       - uses: ./.github/workflows/actions/prepare
       # @see https://github.com/changesets/action
-      - uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
+      - uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
+          github-token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
           title: 'Publish packages 🚀'
           commit: 'Publish packages'
           version: pnpm version-bump
           publish: pnpm changeset tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
 
+permissions: {}
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
@@ -11,13 +13,14 @@ jobs:
     name: Changesets 🦋
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
-          # This (plus the github-token input on the Changesets action) allows other workflows to run on the PR that Changesets creates.
-          token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
+          persist-credentials: false
 
       - uses: ./.github/workflows/actions/prepare
       # @see https://github.com/changesets/action

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,13 +3,19 @@ name: Checks
 on:
   workflow_call:
 
+permissions: {}
+
 jobs:
   lint:
     name: Lint 💅
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: ./.github/workflows/actions/prepare
       - run: pnpm run lint
 
@@ -17,8 +23,12 @@ jobs:
     name: Type check 🧮
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: ./.github/workflows/actions/prepare
       - run: pnpm run type-check
       - run: pnpm run build
@@ -27,8 +37,12 @@ jobs:
     name: Tests 🧪
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: ./.github/workflows/actions/prepare
       - run: pnpm run test --coverage
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -42,8 +56,12 @@ jobs:
     name: Playwright E2E 🎭
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: ./.github/workflows/actions/prepare
       - run: pnpm exec playwright install --with-deps
       - run: pnpm exec playwright test

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/workflows/actions/prepare
       - run: pnpm run lint
 
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/workflows/actions/prepare
       - run: pnpm run type-check
       - run: pnpm run build
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/workflows/actions/prepare
       - run: pnpm run test --coverage
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
           name: coverage-report
@@ -43,11 +43,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/workflows/actions/prepare
       - run: pnpm exec playwright install --with-deps
       - run: pnpm exec playwright test
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -10,4 +12,6 @@ concurrency:
 jobs:
   checks:
     name: Checks 📝
+    permissions:
+      contents: read
     uses: ./.github/workflows/checks.yml

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,9 +6,14 @@ on:
   issue_comment:
     types: [created]
 
+permissions: {}
+
 jobs:
   cla:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      pull-requests: write
     if: |
       (github.event.issue.pull_request 
         && !github.event.issue.pull_request.merged_at

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -16,7 +16,7 @@ jobs:
       ) 
       || (github.event.pull_request && !github.event.pull_request.merged)
     steps:
-      - uses: Shopify/shopify-cla-action@v1
+      - uses: Shopify/shopify-cla-action@9938f4b43524d1cfa7471ce9a803edf226697284 # v1.8.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cla-token: ${{ secrets.CLA_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,12 +11,16 @@ on:
     types:
       - created
 
+permissions: {}
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   checks:
     name: Checks 📝
     if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/checks.yml
 
   deploy:
@@ -30,6 +34,8 @@ jobs:
       id-token: write # Required for OIDC authentication
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: ./.github/workflows/actions/prepare
       - run: pnpm run type-check
       - run: pnpm run build
@@ -48,6 +54,8 @@ jobs:
       id-token: write # Required for OIDC authentication
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: ./.github/workflows/actions/prepare
 
       # Changeset entries are consumed on this branch. We need to reset the
@@ -78,14 +86,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
       id-token: write # Required for OIDC authentication
+      issues: write
+      pull-requests: write
     steps:
       # WARNING: DO NOT RUN ANY CUSTOM LOCAL SCRIPT BEFORE RUNNING THE SNAPIT ACTION
       # This action can be executed by 3rd party users and it should not be able to run arbitrary code from a PR.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
+          persist-credentials: false
 
       - uses: ./.github/workflows/actions/prepare
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # Required for OIDC authentication
+      pull-requests: read # Required for Changesets changelog links
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -75,7 +76,7 @@ jobs:
           pnpm changeset version --snapshot preview
           pnpm changeset publish --tag preview --no-git-tag
         env:
-          GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: '' # Empty string forces OIDC
           NPM_CONFIG_PROVENANCE: true
 
@@ -101,7 +102,7 @@ jobs:
       - name: Create snapshot
         uses: Shopify/snapit@efd7ad2bbc01ba82ac9a8495eb49b3a8eed0d9b9 # v0.1.0
         env:
-          GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: '' # Empty string forces OIDC
           NPM_CONFIG_PROVENANCE: true
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
       contents: read
       id-token: write # Required for OIDC authentication
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/workflows/actions/prepare
       - run: pnpm run type-check
       - run: pnpm run build
@@ -47,7 +47,7 @@ jobs:
       contents: read
       id-token: write # Required for OIDC authentication
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/workflows/actions/prepare
 
       # Changeset entries are consumed on this branch. We need to reset the
@@ -83,14 +83,14 @@ jobs:
     steps:
       # WARNING: DO NOT RUN ANY CUSTOM LOCAL SCRIPT BEFORE RUNNING THE SNAPIT ACTION
       # This action can be executed by 3rd party users and it should not be able to run arbitrary code from a PR.
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
 
       - uses: ./.github/workflows/actions/prepare
 
       - name: Create snapshot
-        uses: Shopify/snapit@v0.1.0
+        uses: Shopify/snapit@efd7ad2bbc01ba82ac9a8495eb49b3a8eed0d9b9 # v0.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
           NPM_TOKEN: '' # Empty string forces OIDC

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,13 +32,17 @@ Run `pnpm lint`, which will run the entire codebase through [Prettier](https://p
 
 Run `pnpm test` to run all tests with [Vitest](https://vitest.dev/guide/). Vitest watches for changes in an interactive development terminal and runs once in CI or other non-interactive environments. Run `pnpm test --coverage` to generate an HTML coverage report in `coverage/` and enforce the package coverage thresholds used in CI.
 
-Tests are currently a little sparse, focused mostly on ensuring good end-to-end behavior when using all the libraries together. Additional tests can be added for public APIs in each package by including files with a `.test.ts` or `.test.tsx` extension. Make sure you adhere to the structure of the other tests in the repo, and it would be extra appreciated if you understand a little about [Shopify’s approach to front-end testing (sorry to external contributors, this is an internal Shopify link)](https://github.com/Shopify/web-foundations/blob/main/handbook/Best%20Practices/Testing.md).
+Tests are currently a little sparse, focused mostly on ensuring good end-to-end behavior when using all the libraries together. Additional tests can be added for public APIs in each package by including files with a `.test.ts` or `.test.tsx` extension. Follow the structure of the existing tests.
 
 #### Build
 
 To build all the package outputs for the repo, run `pnpm build`. This command uses [Rollup](https://rollupjs.org/), with a good set of configuration options provided by [Quilt](https://github.com/lemonmade/quilt/blob/main/documentation/projects/packages/builds.md). Some of these versions, like the `.esnext` version of the project you will see, preserve most of the original source code, so that build tools can be configured to parse, process, polyfill, and minify this code in the same way the rest of an application’s codebase. This helps to significantly reduce the bundle size of these packages.
 
 `pnpm build` runs in CI and before publication. Generated outputs are ignored by Git, but you should run the command locally before submitting changes that affect package output.
+
+### GitHub Actions
+
+Pin external actions to full 40-character commit SHAs with version comments. Adopt stable releases only after seven days and review their migration notes; Dependabot checks weekly with the same cooldown. Keep jobs on `ubuntu-latest`. Validate affected workflow paths without production credentials.
 
 ### Contributing a change
 

--- a/examples/kitchen-sink/README.md
+++ b/examples/kitchen-sink/README.md
@@ -18,3 +18,17 @@ From the root of the repository, run the following command:
 ```bash
 pnpm --filter example-kitchen-sink start
 ```
+
+## Why this example uses Vite 5
+
+Keep this package on Vite 5, Svelte 4, and `@sveltejs/vite-plugin-svelte` 3 as a compatible set. Do not upgrade Vite independently or replace its declaration with the workspace's Vite catalog entry.
+
+The Svelte Vite plugin versions that support Vite 6 and newer require Svelte 5. Svelte 5's client runtime depends on DOM behavior that Remote DOM's minimal Web Worker polyfill does not yet implement. An upgrade may work in the `<iframe>` sandbox while breaking the Web Worker sandbox, which is an essential part of this example.
+
+Before upgrading this package:
+
+1. Add the DOM behavior Svelte 5 requires to the Remote DOM polyfill.
+2. Migrate the example to Svelte 5, including its `mount()` API.
+3. Upgrade the Svelte Vite plugin and other framework plugins to versions compatible with the target Vite version.
+4. Run the full Playwright suite against both iframe and Web Worker sandboxes.
+5. Replace the package's Vite declaration with `catalog:` only after both sandbox modes pass.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ catalog:
   preact: ^10.23.0
   react: ^18.3.0
   react-dom: ^18.3.0
+  # The kitchen-sink example intentionally stays on Vite 5. See its README.
   vite: ^8.0.0
 
 # Allow only reviewed dependency lifecycle scripts.


### PR DESCRIPTION
## What changed

This updates the GitHub Actions used by the repository and pins each external action to a reviewed commit. It also adds a seven-day delay before Dependabot proposes newly released action versions.

Future GitHub Action updates will be grouped into one pull request. Dependabot will keep Changesets on v1 until the repository deliberately upgrades to Changesets CLI v3.

The workflows now declare the permissions they need instead of inheriting the repository's broad defaults. Checkout credentials are no longer left available to later steps.

The custom GitHub App token is now used only by Changesets, where it is needed so updates to the release PR trigger the usual checks. Preview publishing and Snapit use the job's built-in GitHub token.

The workflows continue to use `ubuntu-latest`, and the maintenance policy is documented in `CONTRIBUTING.md`.

## Validation

- Parsed all workflow and Dependabot YAML
- Ran repository lint, type checking, builds, unit coverage, and Playwright tests
- Verified every external action uses a 40-character commit SHA
- Verified the workflow permission matrix
- Verified all checkout steps disable credential persistence
- Verified Changesets is the only remaining custom-token call site

The protected release, preview, CLA, and Snapit event paths will be checked through their normal repository events after merge rather than simulated locally with production credentials.

No changeset is needed because this changes repository automation and documentation only.
