### PR TITLE
Tighten TypeScript syntax checks

### DIFF
--- a/examples/kitchen-sink/app/remote/examples/react-remote-ui.tsx
+++ b/examples/kitchen-sink/app/remote/examples/react-remote-ui.tsx
@@ -3,7 +3,7 @@
 import {retain} from '@quilted/threads';
 
 import {createRemoteReactComponent} from '@remote-ui/react';
-import {
+import type {
   ButtonProperties,
   ModalProperties,
   RenderAPI,
@@ -12,7 +12,7 @@ import {
 } from '../../types';
 import {useState} from 'react';
 import {createRoot, createRemoteRoot} from '@remote-ui/react';
-import {RemoteChannel} from '@remote-ui/core';
+import type {RemoteChannel} from '@remote-ui/core';
 
 const Button = createRemoteReactComponent<
   'Button',

--- a/examples/kitchen-sink/app/remote/render.ts
+++ b/examples/kitchen-sink/app/remote/render.ts
@@ -1,4 +1,4 @@
-import {RemoteChannel} from '@remote-ui/core';
+import type {RemoteChannel} from '@remote-ui/core';
 import type {RenderAPI} from '../types.ts';
 
 // Defines the custom elements available to render in the remote environment.

--- a/examples/kitchen-sink/app/types.ts
+++ b/examples/kitchen-sink/app/types.ts
@@ -1,5 +1,5 @@
 import type {RemoteConnection} from '@remote-dom/core';
-import {RemoteChannel} from '@remote-ui/core';
+import type {RemoteChannel} from '@remote-ui/core';
 
 /**
  * Describes the technology used to sandbox the “remote” code, so that it does

--- a/examples/kitchen-sink/tsconfig.json
+++ b/examples/kitchen-sink/tsconfig.json
@@ -1,9 +1,7 @@
 {
-  "extends": [
-    "@quilted/typescript/tsconfig.project.json",
-    "../../tsconfig.shared.json"
-  ],
+  "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
+    "rootDir": ".",
     "outDir": "build/typescript",
     "jsx": "react-jsx",
     "jsxImportSource": "preact"

--- a/examples/kitchen-sink/tsconfig.json
+++ b/examples/kitchen-sink/tsconfig.json
@@ -1,5 +1,8 @@
 {
-  "extends": "@quilted/typescript/tsconfig.project.json",
+  "extends": [
+    "@quilted/typescript/tsconfig.project.json",
+    "../../tsconfig.shared.json"
+  ],
   "compilerOptions": {
     "outDir": "build/typescript",
     "jsx": "react-jsx",

--- a/packages/compat/tsconfig.json
+++ b/packages/compat/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "extends": [
-    "@quilted/typescript/tsconfig.package.json",
-    "../../tsconfig.shared.json"
-  ],
+  "extends": "../../tsconfig.shared.json",
   "references": [{"path": "../core"}]
 }

--- a/packages/compat/tsconfig.json
+++ b/packages/compat/tsconfig.json
@@ -1,4 +1,7 @@
 {
-  "extends": "@quilted/typescript/tsconfig.package.json",
+  "extends": [
+    "@quilted/typescript/tsconfig.package.json",
+    "../../tsconfig.shared.json"
+  ],
   "references": [{"path": "../core"}]
 }

--- a/packages/core/source/elements/tests/connection.test.ts
+++ b/packages/core/source/elements/tests/connection.test.ts
@@ -2,7 +2,7 @@ import '../../polyfill/polyfill.ts';
 
 import {afterEach, describe, expect, it, vi, type MockedObject} from 'vitest';
 
-import {BatchingRemoteConnection, RemoteConnection} from '../../elements';
+import {BatchingRemoteConnection, type RemoteConnection} from '../../elements';
 
 describe('BatchingRemoteConnection', () => {
   afterEach(() => {

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,4 +1,7 @@
 {
-  "extends": "@quilted/typescript/tsconfig.package.json",
+  "extends": [
+    "@quilted/typescript/tsconfig.package.json",
+    "../../tsconfig.shared.json"
+  ],
   "references": [{"path": "../polyfill"}]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "extends": [
-    "@quilted/typescript/tsconfig.package.json",
-    "../../tsconfig.shared.json"
-  ],
+  "extends": "../../tsconfig.shared.json",
   "references": [{"path": "../polyfill"}]
 }

--- a/packages/polyfill/source/Event.ts
+++ b/packages/polyfill/source/Event.ts
@@ -6,6 +6,8 @@ import {
 } from './constants.ts';
 import type {EventTarget} from './EventTarget.ts';
 
+// TODO: Replace this enum with one-way constants, matching the DOM and Web IDL.
+// @ts-expect-error -- Legacy enum; keep this exception scoped to this declaration.
 export const enum EventPhase {
   NONE = 0,
   CAPTURING_PHASE = 1,
@@ -54,6 +56,7 @@ export class Event {
   [STOP_IMMEDIATE_PROPAGATION] = false;
 
   constructor(
+    // @ts-expect-error -- Legacy parameter property; keep this exception scoped to this declaration.
     public type: string,
     options?: EventInit,
   ) {

--- a/packages/polyfill/source/constants.ts
+++ b/packages/polyfill/source/constants.ts
@@ -18,7 +18,8 @@ export const CONTENT = Symbol('content');
 export const HOOKS = Symbol('hooks');
 export const IS_CONNECTED = Symbol('is_connected');
 
-// @TODO remove explicit values
+// TODO: Replace this enum with one-way constants, matching the DOM and Web IDL.
+// @ts-expect-error -- Legacy enum; keep this exception scoped to this declaration.
 export const enum NodeType {
   NODE = 0,
   ELEMENT_NODE = 1,
@@ -34,6 +35,8 @@ export const enum NodeType {
   DOCUMENT_FRAGMENT_NODE = 11,
 }
 
+// TODO: Replace this enum with namespace string constants, matching the DOM.
+// @ts-expect-error -- Legacy enum; keep this exception scoped to this declaration.
 export const enum NamespaceURI {
   XHTML = 'http://www.w3.org/1999/xhtml',
   SVG = 'http://www.w3.org/2000/svg',

--- a/packages/polyfill/source/selectors.ts
+++ b/packages/polyfill/source/selectors.ts
@@ -5,6 +5,8 @@ import type {Node} from './Node.ts';
 import type {Element} from './Element.ts';
 import type {ParentNode} from './ParentNode.ts';
 
+// TODO: Replace this enum with an erasable constant object.
+// @ts-expect-error -- Legacy enum; keep this exception scoped to this declaration.
 const enum Combinator {
   Descendant,
   Child,
@@ -13,6 +15,8 @@ const enum Combinator {
   Inner,
 }
 
+// TODO: Replace this enum with an erasable constant object.
+// @ts-expect-error -- Legacy enum; keep this exception scoped to this declaration.
 const enum MatcherType {
   Unknown,
   Element,

--- a/packages/polyfill/tsconfig.json
+++ b/packages/polyfill/tsconfig.json
@@ -1,4 +1,7 @@
 {
-  "extends": "@quilted/typescript/tsconfig.package.json",
+  "extends": [
+    "@quilted/typescript/tsconfig.package.json",
+    "../../tsconfig.shared.json"
+  ],
   "references": []
 }

--- a/packages/polyfill/tsconfig.json
+++ b/packages/polyfill/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "extends": [
-    "@quilted/typescript/tsconfig.package.json",
-    "../../tsconfig.shared.json"
-  ],
+  "extends": "../../tsconfig.shared.json",
   "references": []
 }

--- a/packages/preact/tsconfig.json
+++ b/packages/preact/tsconfig.json
@@ -1,5 +1,8 @@
 {
-  "extends": "@quilted/typescript/tsconfig.package.json",
+  "extends": [
+    "@quilted/typescript/tsconfig.package.json",
+    "../../tsconfig.shared.json"
+  ],
   "compilerOptions": {
     "jsx": "react-jsx",
     "jsxImportSource": "preact"

--- a/packages/preact/tsconfig.json
+++ b/packages/preact/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": [
-    "@quilted/typescript/tsconfig.package.json",
-    "../../tsconfig.shared.json"
-  ],
+  "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
     "jsx": "react-jsx",
     "jsxImportSource": "preact"

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,5 +1,8 @@
 {
-  "extends": "@quilted/typescript/tsconfig.package.json",
+  "extends": [
+    "@quilted/typescript/tsconfig.package.json",
+    "../../tsconfig.shared.json"
+  ],
   "compilerOptions": {
     "jsx": "react-jsx"
   },

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": [
-    "@quilted/typescript/tsconfig.package.json",
-    "../../tsconfig.shared.json"
-  ],
+  "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
     "jsx": "react-jsx"
   },

--- a/packages/signals/tsconfig.json
+++ b/packages/signals/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "extends": [
-    "@quilted/typescript/tsconfig.package.json",
-    "../../tsconfig.shared.json"
-  ],
+  "extends": "../../tsconfig.shared.json",
   "references": [{"path": "../core"}]
 }

--- a/packages/signals/tsconfig.json
+++ b/packages/signals/tsconfig.json
@@ -1,4 +1,7 @@
 {
-  "extends": "@quilted/typescript/tsconfig.package.json",
+  "extends": [
+    "@quilted/typescript/tsconfig.package.json",
+    "../../tsconfig.shared.json"
+  ],
   "references": [{"path": "../core"}]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": [
-    "@quilted/typescript/tsconfig.workspace.json",
-    "./tsconfig.shared.json"
-  ],
+  "extends": "./tsconfig.shared.json",
   "files": [],
   "include": [],
   "references": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
-  "extends": "@quilted/typescript/tsconfig.workspace.json",
+  "extends": [
+    "@quilted/typescript/tsconfig.workspace.json",
+    "./tsconfig.shared.json"
+  ],
   "files": [],
   "include": [],
   "references": [

--- a/tsconfig.shared.json
+++ b/tsconfig.shared.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "verbatimModuleSyntax": true
+  }
+}

--- a/tsconfig.shared.json
+++ b/tsconfig.shared.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowUnusedLabels": false,
     "erasableSyntaxOnly": true,
     "verbatimModuleSyntax": true
   }

--- a/tsconfig.shared.json
+++ b/tsconfig.shared.json
@@ -1,4 +1,5 @@
 {
+  "extends": "@quilted/typescript/tsconfig.package.json",
   "compilerOptions": {
     "allowUnusedLabels": false,
     "erasableSyntaxOnly": true,

--- a/tsconfig.shared.json
+++ b/tsconfig.shared.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "erasableSyntaxOnly": true,
     "verbatimModuleSyntax": true
   }
 }


### PR DESCRIPTION
## What changed

This makes TypeScript stricter across the repository. It now catches unused labels, TypeScript syntax that needs runtime transformation, and imports that should only be used for types.

The settings live in one shared configuration used by every package and the kitchen sink example. Existing polyfill syntax that does not meet the new rules has narrow exceptions and TODOs so it can be cleaned up separately without weakening checks elsewhere.

## Testing

- `pnpm lint`
- `pnpm exec tsc --build --pretty --force`
- `pnpm build`
- `pnpm run test --coverage` — 174 tests passed
- `pnpm exec playwright test` — 13 tests passed
