### PR TITLE
Fix Node#contains infinite loop for indirect descendants

### DIFF
--- a/packages/polyfill/source/Node.ts
+++ b/packages/polyfill/source/Node.ts
@@ -160,7 +160,7 @@ export class Node extends EventTarget {
     while (true) {
       if (currentNode == null) return false;
       if (currentNode === this) return true;
-      currentNode = node!.parentNode;
+      currentNode = currentNode.parentNode;
     }
   }
 }

--- a/packages/polyfill/source/tests/node.test.ts
+++ b/packages/polyfill/source/tests/node.test.ts
@@ -1,0 +1,60 @@
+import {Window} from '../index.ts';
+
+import {describe, it, expect, beforeEach} from 'vitest';
+
+describe('Node#contains', () => {
+  beforeEach(() => {
+    const window = new Window();
+    Window.setGlobalThis(window);
+  });
+
+  it('returns true for a direct child', () => {
+    const parent = document.createElement('div');
+    const child = document.createElement('span');
+    parent.append(child);
+
+    expect(parent.contains(child)).toBe(true);
+  });
+
+  it('returns true for an indirect descendant', () => {
+    const ancestor = document.createElement('div');
+    const middle = document.createElement('div');
+    const descendant = document.createElement('span');
+    middle.append(descendant);
+    ancestor.append(middle);
+
+    // The walk used to re-read the original node's parentNode instead of
+    // advancing, so any indirect descendant looped forever.
+    expect(ancestor.contains(descendant)).toBe(true);
+  });
+
+  it('returns true for the node itself', () => {
+    const element = document.createElement('div');
+
+    expect(element.contains(element)).toBe(true);
+  });
+
+  it('returns false for a detached node', () => {
+    const element = document.createElement('div');
+    const detached = document.createElement('span');
+
+    expect(element.contains(detached)).toBe(false);
+  });
+
+  it('returns false for sibling subtrees', () => {
+    const root = document.createElement('div');
+    const left = document.createElement('div');
+    const right = document.createElement('div');
+    const rightChild = document.createElement('span');
+    right.append(rightChild);
+    root.append(left, right);
+
+    expect(left.contains(rightChild)).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    const element = document.createElement('div');
+
+    expect(element.contains(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What?

`Node#contains()` never terminates for any **indirect** descendant: the walk re-reads the original node's `parentNode` on every iteration instead of advancing.

```ts
contains(node: Node | null) {
  let currentNode: Node | null = node;
  while (true) {
    if (currentNode == null) return false;
    if (currentNode === this) return true;
    currentNode = node!.parentNode;   // ← never advances past the argument's own parent
  }
}
```

For a **direct** child the first step happens to hit the receiver and returns `true` — which makes the bug look intermittent: only deeper nesting hangs. For an indirect descendant the loop re-reads the same middle node forever. In a synchronous environment — a Web Worker running the polyfill as its DOM — that single call deadlocks the whole event loop with no exception and no recovery short of terminating the worker.

This is reported downstream in the wild: twenty's front-component Remote DOM worker freezes permanently whenever a component hit-tests with `Element.contains()` on anything nested deeper than one level ([twentyhq/twenty#24573](https://github.com/twentyhq/twenty/issues/24573)); a maintainer-confirmed MEDIUM with the worker's timers and direct `fetch` heartbeats all stopping at the call site.

## Fix

Advance the walk with `currentNode.parentNode`, per the `Node.prototype.contains` contract.

## Testing

New `packages/polyfill/source/tests/node.test.ts` (vitest, same harness as the existing `serialization.test.ts`): direct child, **indirect descendant** (the hanging case), self, detached node, sibling subtrees, and `null` — 6/6 pass.

**Differential**: on the previous code the indirect-descendant case does not merely fail — it hangs the runner indefinitely (the run had to be killed after several minutes; an isolated child-process repro of the exact loop also never terminates against a three-level chain). With the change the whole file passes in under five seconds.