### PR TITLE
Add missing Polyfill changeset

### DIFF
--- a/.changeset/calm-tools-initialize.md
+++ b/.changeset/calm-tools-initialize.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/polyfill': patch
+---
+
+Add the missing `CustomElementRegistry.initialize()` compatibility method so TypeScript 7 type checks cleanly.


### PR DESCRIPTION
## Summary

- add a patch changeset for `@remote-dom/polyfill`
- document the `CustomElementRegistry.initialize()` compatibility method introduced in #633

This is a follow-up to the recently merged infrastructure modernization PR.