### PR TITLE
Composable polyfill extensions

### DIFF
--- a/.changeset/sharp-pillows-talk.md
+++ b/.changeset/sharp-pillows-talk.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/polyfill': minor
+---
+
+Add composable `Window` extensions for installing DOM APIs and subscribing to DOM operations.

--- a/packages/polyfill/README.md
+++ b/packages/polyfill/README.md
@@ -45,17 +45,14 @@ import {Window, type WindowExtension} from '@remote-dom/polyfill';
 
 class CustomMutationObserver {}
 
-const mutationObserverExtension: WindowExtension = {
-  name: 'mutation-observer',
-  install(window) {
-    window.MutationObserver = CustomMutationObserver;
+const mutationObserverExtension: WindowExtension = (window) => {
+  window.MutationObserver = CustomMutationObserver;
 
-    return {
-      setAttribute(element, name, value) {
-        // Notify observers associated with this window.
-      },
-    };
-  },
+  return {
+    setAttribute(element, name, value) {
+      // Notify observers associated with this window.
+    },
+  };
 };
 
 const ExtendedWindow = Window.with(mutationObserverExtension);
@@ -68,9 +65,9 @@ are called in the same order for each DOM operation.
 Extensions are installed after the base window and its initial document have
 been constructed, so their hooks do not observe the document’s bootstrap.
 
-For low-level integrations, hooks can also be assigned directly through the
-exported `HOOKS` symbol. Extension hooks run first, followed by the hook
-assigned through `window[HOOKS]`:
+Assigning hooks directly through the exported `HOOKS` symbol is the legacy
+integration API. New integrations should use extensions instead. Extension
+hooks run first, followed by the legacy hook assigned through `window[HOOKS]`:
 
 ```ts
 import {HOOKS} from '@remote-dom/polyfill';

--- a/packages/polyfill/README.md
+++ b/packages/polyfill/README.md
@@ -37,8 +37,15 @@ This process will install polyfilled versions of the following globals:
 ## Extensions
 
 Use `Window.with()` to create a reusable `Window` subclass with additional DOM
-APIs or behavior. Each extension installs itself on every new window and can
-return hooks that subscribe to DOM operations:
+APIs or behavior. An extension is a function with two distinct parts:
+
+- **The function body runs once per window, during construction.** It receives
+  the new `Window` instance and can install or replace APIs on it, like
+  `window.MutationObserver`. Use it for setup, not for reacting to DOM changes.
+- **The returned hooks run for the lifetime of the window.** They subscribe to
+  DOM operations on that window, such as creating elements, setting attributes,
+  and adding event listeners, and are called each time one of those operations
+  happens. Returning hooks is optional.
 
 ```ts
 import {Window, type WindowExtension} from '@remote-dom/polyfill';
@@ -46,8 +53,10 @@ import {Window, type WindowExtension} from '@remote-dom/polyfill';
 class CustomMutationObserver {}
 
 const mutationObserverExtension: WindowExtension = (window) => {
+  // Construction time: extend this window instance.
   window.MutationObserver = CustomMutationObserver;
 
+  // Runtime: subscribe to DOM operations on this window.
   return {
     setAttribute(element, name, value) {
       // Notify observers associated with this window.
@@ -59,8 +68,14 @@ const ExtendedWindow = Window.with(mutationObserverExtension);
 const window = new ExtendedWindow();
 ```
 
-Extensions are installed in the order passed to `Window.with()`. Their hooks
-are called in the same order for each DOM operation.
+Extensions are installed in the order passed to `Window.with()` and across
+chained `.with()` calls. The two parts compose differently:
+
+- **Window APIs override.** Assignments like `window.MutationObserver = …` are
+  plain property writes, so when multiple extensions set the same API, the last
+  extension installed wins.
+- **Hooks are additive.** Every installed extension’s hooks are called in
+  installation order for each DOM operation.
 
 Extensions are installed after the base window and its initial document have
 been constructed, so their hooks do not observe the document’s bootstrap.

--- a/packages/polyfill/README.md
+++ b/packages/polyfill/README.md
@@ -34,12 +34,48 @@ This process will install polyfilled versions of the following globals:
 - [`location`](https://developer.mozilla.org/en-US/docs/Web/API/Window/location) and [`navigator`](https://developer.mozilla.org/en-US/docs/Web/API/Window/navigator), though these are just set to `globalThis.location` and `globalThis.navigator`.
 - The [`Event`](https://developer.mozilla.org/en-US/docs/Web/API/Event), [`EventTarget`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget), [`CustomEvent`](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent), [`Node`](https://developer.mozilla.org/en-US/docs/Web/API/Node), [`ParentNode`](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode), [`ChildNode`](https://developer.mozilla.org/en-US/docs/Web/API/ChildNode), [`Document`](https://developer.mozilla.org/en-US/docs/Web/API/Document), [`DocumentFragment`](https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment), [`CharacterData`](https://developer.mozilla.org/en-US/docs/Web/API/CharacterData), [`Comment`](https://developer.mozilla.org/en-US/docs/Web/API/Comment), [`Text`](https://developer.mozilla.org/en-US/docs/Web/API/Text), [`Element`](https://developer.mozilla.org/en-US/docs/Web/API/Element), [`HTMLElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement), [`SVGElement`](https://developer.mozilla.org/en-US/docs/Web/API/SVGElement), [`HTMLTemplateElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLTemplateElement), and [`MutationObserver`](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) constructors.
 
-This polyfill lets you hook into many of the operations that happen in the DOM, like creating elements, updating attributes, and adding event listeners. You define these hooks by overwriting any of the properties on the `hooks` export of this library.
+## Extensions
+
+Use `Window.with()` to create a reusable `Window` subclass with additional DOM
+APIs or behavior. Each extension installs itself on every new window and can
+return hooks that subscribe to DOM operations:
 
 ```ts
-import {hooks} from '@remote-dom/polyfill';
+import {Window, type WindowExtension} from '@remote-dom/polyfill';
 
-hooks.createElement = (element) => {
+class CustomMutationObserver {}
+
+const mutationObserverExtension: WindowExtension = {
+  name: 'mutation-observer',
+  install(window) {
+    window.MutationObserver = CustomMutationObserver;
+
+    return {
+      setAttribute(element, name, value) {
+        // Notify observers associated with this window.
+      },
+    };
+  },
+};
+
+const ExtendedWindow = Window.with(mutationObserverExtension);
+const window = new ExtendedWindow();
+```
+
+Extensions are installed in the order passed to `Window.with()`. Their hooks
+are called in the same order for each DOM operation.
+
+Extensions are installed after the base window and its initial document have
+been constructed, so their hooks do not observe the document’s bootstrap.
+
+For low-level integrations, hooks can also be assigned directly through the
+exported `HOOKS` symbol. Extension hooks run first, followed by the hook
+assigned through `window[HOOKS]`:
+
+```ts
+import {HOOKS} from '@remote-dom/polyfill';
+
+window[HOOKS].createElement = (element) => {
   console.log('Creating element:', element);
 };
 ```

--- a/packages/polyfill/source/EventTarget.ts
+++ b/packages/polyfill/source/EventTarget.ts
@@ -1,4 +1,4 @@
-import {HOOKS, PATH, LISTENERS, OWNER_DOCUMENT} from './constants.ts';
+import {HOOKS_DISPATCH, PATH, LISTENERS, OWNER_DOCUMENT} from './constants.ts';
 import {
   EVENT_PHASE_BUBBLING,
   EVENT_PHASE_CAPTURING,
@@ -82,7 +82,7 @@ export class EventTarget {
     );
 
     list.add(normalizedListener);
-    this[OWNER_DOCUMENT]?.defaultView[HOOKS].addEventListener?.(
+    this[OWNER_DOCUMENT]?.defaultView[HOOKS_DISPATCH].addEventListener?.(
       this as any,
       type,
       listener,
@@ -153,7 +153,7 @@ function removeEventListener(
   if (list) {
     const deleted = list.delete(normalizedListener);
     if (deleted) {
-      this[OWNER_DOCUMENT]?.defaultView[HOOKS].removeEventListener?.(
+      this[OWNER_DOCUMENT]?.defaultView[HOOKS_DISPATCH].removeEventListener?.(
         this as any,
         type,
         listener,

--- a/packages/polyfill/source/Node.ts
+++ b/packages/polyfill/source/Node.ts
@@ -9,6 +9,7 @@ import {
   NODE_TYPE_NODE,
   type NodeType,
   HOOKS,
+  HOOKS_DISPATCH,
   IS_CONNECTED,
 } from './constants.ts';
 import type {Document} from './Document.ts';
@@ -34,7 +35,7 @@ export class Node extends EventTarget {
   [IS_CONNECTED] = false;
 
   protected get [HOOKS]() {
-    return this[OWNER_DOCUMENT].defaultView[HOOKS];
+    return this[OWNER_DOCUMENT].defaultView[HOOKS_DISPATCH];
   }
 
   get localName() {

--- a/packages/polyfill/source/Window.ts
+++ b/packages/polyfill/source/Window.ts
@@ -20,7 +20,8 @@ import {DocumentFragment} from './DocumentFragment.ts';
 import {HTMLTemplateElement} from './HTMLTemplateElement.ts';
 import {CustomElementRegistryImplementation} from './CustomElementRegistry.ts';
 import {MutationObserver} from './MutationObserver.ts';
-import {HOOKS} from './constants.ts';
+import {EXTENSIONS, HOOKS, HOOKS_DISPATCH} from './constants.ts';
+import type {WindowExtension} from './extensions.ts';
 import type {Hooks} from './hooks.ts';
 
 type OnErrorHandler =
@@ -33,8 +34,15 @@ type OnErrorHandler =
     ) => void)
   | null;
 
+interface InstalledWindowExtension {
+  readonly name: string;
+  readonly hooks: Partial<Hooks>;
+}
+
 export class Window extends EventTarget {
   [HOOKS]: Partial<Hooks> = {};
+  [EXTENSIONS]: InstalledWindowExtension[] = [];
+  [HOOKS_DISPATCH]: Hooks = createHooksDispatcher(this);
   name = '';
   window = this;
   parent = this;
@@ -70,6 +78,20 @@ export class Window extends EventTarget {
   #currentOriginalOnErrorHandler: OnErrorHandler = null;
   #currentOnUnhandledRejectionHandler: WindowEventHandlers['onunhandledrejection'] =
     null;
+
+  static with(...extensions: readonly WindowExtension[]): typeof Window {
+    const BaseWindow = this;
+
+    return class ExtendedWindow extends BaseWindow {
+      constructor() {
+        super();
+
+        for (const extension of extensions) {
+          installExtension(this, extension);
+        }
+      }
+    };
+  }
 
   get onerror() {
     return this.#currentOriginalOnErrorHandler;
@@ -167,4 +189,48 @@ export class Window extends EventTarget {
     Object.defineProperties(globalThis, properties);
     Object.defineProperties(globalThis, eventTargetPrototypeProperties);
   }
+}
+
+function installExtension(window: Window, extension: WindowExtension) {
+  if (window[EXTENSIONS].some(({name}) => name === extension.name)) {
+    throw new Error(
+      `An extension named ${JSON.stringify(extension.name)} is already installed on this window.`,
+    );
+  }
+
+  const hooks = extension.install(window) ?? {};
+  window[EXTENSIONS].push({name: extension.name, hooks});
+}
+
+function createHooksDispatcher(window: Window): Hooks {
+  return {
+    createElement: (...args) => dispatchHook(window, 'createElement', args),
+    setAttribute: (...args) => dispatchHook(window, 'setAttribute', args),
+    removeAttribute: (...args) => dispatchHook(window, 'removeAttribute', args),
+    createText: (...args) => dispatchHook(window, 'createText', args),
+    setText: (...args) => dispatchHook(window, 'setText', args),
+    insertChild: (...args) => dispatchHook(window, 'insertChild', args),
+    removeChild: (...args) => dispatchHook(window, 'removeChild', args),
+    addEventListener: (...args) =>
+      dispatchHook(window, 'addEventListener', args),
+    removeEventListener: (...args) =>
+      dispatchHook(window, 'removeEventListener', args),
+  };
+}
+
+function dispatchHook<Name extends keyof Hooks>(
+  window: Window,
+  name: Name,
+  args: Parameters<Hooks[Name]>,
+) {
+  for (const extension of window[EXTENSIONS]) {
+    const hook = extension.hooks[name] as
+      | ((...args: any[]) => void)
+      | undefined;
+    hook?.apply(extension.hooks, args);
+  }
+
+  const hooks = window[HOOKS];
+  const legacyHook = hooks[name] as ((...args: any[]) => void) | undefined;
+  legacyHook?.apply(hooks, args);
 }

--- a/packages/polyfill/source/Window.ts
+++ b/packages/polyfill/source/Window.ts
@@ -34,14 +34,9 @@ type OnErrorHandler =
     ) => void)
   | null;
 
-interface InstalledWindowExtension {
-  readonly name: string;
-  readonly hooks: Partial<Hooks>;
-}
-
 export class Window extends EventTarget {
   [HOOKS]: Partial<Hooks> = {};
-  [EXTENSIONS]: InstalledWindowExtension[] = [];
+  [EXTENSIONS]: Partial<Hooks>[] = [];
   [HOOKS_DISPATCH]: Hooks = createHooksDispatcher(this);
   name = '';
   window = this;
@@ -192,45 +187,30 @@ export class Window extends EventTarget {
 }
 
 function installExtension(window: Window, extension: WindowExtension) {
-  if (window[EXTENSIONS].some(({name}) => name === extension.name)) {
-    throw new Error(
-      `An extension named ${JSON.stringify(extension.name)} is already installed on this window.`,
-    );
-  }
-
-  const hooks = extension.install(window) ?? {};
-  window[EXTENSIONS].push({name: extension.name, hooks});
+  window[EXTENSIONS].push(extension(window) ?? {});
 }
 
 function createHooksDispatcher(window: Window): Hooks {
   return {
-    createElement: (...args) => dispatchHook(window, 'createElement', args),
-    setAttribute: (...args) => dispatchHook(window, 'setAttribute', args),
-    removeAttribute: (...args) => dispatchHook(window, 'removeAttribute', args),
-    createText: (...args) => dispatchHook(window, 'createText', args),
-    setText: (...args) => dispatchHook(window, 'setText', args),
-    insertChild: (...args) => dispatchHook(window, 'insertChild', args),
-    removeChild: (...args) => dispatchHook(window, 'removeChild', args),
-    addEventListener: (...args) =>
-      dispatchHook(window, 'addEventListener', args),
-    removeEventListener: (...args) =>
-      dispatchHook(window, 'removeEventListener', args),
+    createElement: dispatchHook.bind(null, window, 'createElement'),
+    setAttribute: dispatchHook.bind(null, window, 'setAttribute'),
+    removeAttribute: dispatchHook.bind(null, window, 'removeAttribute'),
+    createText: dispatchHook.bind(null, window, 'createText'),
+    setText: dispatchHook.bind(null, window, 'setText'),
+    insertChild: dispatchHook.bind(null, window, 'insertChild'),
+    removeChild: dispatchHook.bind(null, window, 'removeChild'),
+    addEventListener: dispatchHook.bind(null, window, 'addEventListener'),
+    removeEventListener: dispatchHook.bind(null, window, 'removeEventListener'),
   };
 }
 
-function dispatchHook<Name extends keyof Hooks>(
-  window: Window,
-  name: Name,
-  args: Parameters<Hooks[Name]>,
-) {
-  for (const extension of window[EXTENSIONS]) {
-    const hook = extension.hooks[name] as
-      | ((...args: any[]) => void)
-      | undefined;
-    hook?.apply(extension.hooks, args);
+function dispatchHook(window: Window, name: keyof Hooks, ...args: unknown[]) {
+  for (const hooks of window[EXTENSIONS]) {
+    const hook = hooks[name] as ((...args: unknown[]) => void) | undefined;
+    hook?.apply(hooks, args);
   }
 
   const hooks = window[HOOKS];
-  const legacyHook = hooks[name] as ((...args: any[]) => void) | undefined;
+  const legacyHook = hooks[name] as ((...args: unknown[]) => void) | undefined;
   legacyHook?.apply(hooks, args);
 }

--- a/packages/polyfill/source/constants.ts
+++ b/packages/polyfill/source/constants.ts
@@ -16,6 +16,8 @@ export const PATH = Symbol('path');
 export const STOP_IMMEDIATE_PROPAGATION = Symbol('stop_immediate_propagation');
 export const CONTENT = Symbol('content');
 export const HOOKS = Symbol('hooks');
+export const EXTENSIONS = Symbol('extensions');
+export const HOOKS_DISPATCH = Symbol('hooks_dispatch');
 export const IS_CONNECTED = Symbol('is_connected');
 
 export const NODE_TYPE_NODE = 0;

--- a/packages/polyfill/source/extensions.ts
+++ b/packages/polyfill/source/extensions.ts
@@ -1,7 +1,4 @@
 import type {Hooks} from './hooks.ts';
 import type {Window} from './Window.ts';
 
-export interface WindowExtension {
-  readonly name: string;
-  install(window: Window): Partial<Hooks> | void;
-}
+export type WindowExtension = (window: Window) => Partial<Hooks> | void;

--- a/packages/polyfill/source/extensions.ts
+++ b/packages/polyfill/source/extensions.ts
@@ -1,0 +1,7 @@
+import type {Hooks} from './hooks.ts';
+import type {Window} from './Window.ts';
+
+export interface WindowExtension {
+  readonly name: string;
+  install(window: Window): Partial<Hooks> | void;
+}

--- a/packages/polyfill/source/index.ts
+++ b/packages/polyfill/source/index.ts
@@ -1,4 +1,5 @@
 export {type Hooks} from './hooks.ts';
+export {type WindowExtension} from './extensions.ts';
 export {HOOKS} from './constants.ts';
 export {Window} from './Window.ts';
 export {HTMLElement} from './HTMLElement.ts';

--- a/packages/polyfill/source/tests/extensions.test.ts
+++ b/packages/polyfill/source/tests/extensions.test.ts
@@ -1,0 +1,172 @@
+import {describe, expect, it, vi} from 'vitest';
+
+import {HOOKS} from '../constants.ts';
+import type {WindowExtension} from '../extensions.ts';
+import type {Hooks} from '../hooks.ts';
+import {Window} from '../Window.ts';
+
+describe('Window extensions', () => {
+  it('creates reusable Window subclasses', () => {
+    const installs: string[] = [];
+    const first = extension('first', () => {
+      installs.push('first');
+    });
+    const second = extension('second', () => {
+      installs.push('second');
+    });
+    const ExtendedWindow = Window.with(first, second);
+
+    const firstWindow = new ExtendedWindow();
+    const secondWindow = new ExtendedWindow();
+
+    expect(firstWindow).toBeInstanceOf(Window);
+    expect(secondWindow).toBeInstanceOf(Window);
+    expect(installs).toEqual(['first', 'second', 'first', 'second']);
+  });
+
+  it('composes extensions across successive calls to with()', () => {
+    const installs: string[] = [];
+    const FirstWindow = Window.with(
+      extension('first', () => {
+        installs.push('first');
+      }),
+    );
+    const ExtendedWindow = FirstWindow.with(
+      extension('second', () => {
+        installs.push('second');
+      }),
+    );
+
+    new ExtendedWindow();
+
+    expect(installs).toEqual(['first', 'second']);
+  });
+
+  it('rejects duplicate extension names', () => {
+    const first = extension('duplicate', () => {});
+    const duplicate = extension('duplicate', () => {});
+    const ExtendedWindow = Window.with(first, duplicate);
+    const ChainedWindow = Window.with(first).with(duplicate);
+
+    expect(() => new ExtendedWindow()).toThrow(
+      'An extension named "duplicate" is already installed on this window.',
+    );
+    expect(() => new ChainedWindow()).toThrow(
+      'An extension named "duplicate" is already installed on this window.',
+    );
+  });
+
+  it('dispatches DOM operations to installed hook subscriptions', () => {
+    const hooks = {
+      createElement: vi.fn<Hooks['createElement']>(),
+      setAttribute: vi.fn<Hooks['setAttribute']>(),
+      removeAttribute: vi.fn<Hooks['removeAttribute']>(),
+      createText: vi.fn<Hooks['createText']>(),
+      setText: vi.fn<Hooks['setText']>(),
+      insertChild: vi.fn<Hooks['insertChild']>(),
+      removeChild: vi.fn<Hooks['removeChild']>(),
+      addEventListener: vi.fn<Hooks['addEventListener']>(),
+      removeEventListener: vi.fn<Hooks['removeEventListener']>(),
+    } satisfies Hooks;
+    const ExtendedWindow = Window.with(extension('hooks', () => hooks));
+    const window = new ExtendedWindow();
+
+    const parent = window.document.createElement('parent');
+    const child = window.document.createElement('child');
+    const text = window.document.createTextNode('initial');
+    const listener = () => {};
+
+    parent.setAttribute('attribute', 'value');
+    parent.removeAttribute('attribute');
+    text.data = 'updated';
+    parent.appendChild(child);
+    parent.removeChild(child);
+    parent.addEventListener('event', listener);
+    parent.removeEventListener('event', listener);
+
+    expect(hooks.createElement).toHaveBeenCalledTimes(2);
+    expect(hooks.createText).toHaveBeenCalledOnce();
+    expect(hooks.setText).toHaveBeenCalledOnce();
+    expect(hooks.setAttribute).toHaveBeenCalledOnce();
+    expect(hooks.removeAttribute).toHaveBeenCalledOnce();
+    expect(hooks.insertChild).toHaveBeenCalledOnce();
+    expect(hooks.removeChild).toHaveBeenCalledOnce();
+    expect(hooks.addEventListener).toHaveBeenCalledOnce();
+    expect(hooks.removeEventListener).toHaveBeenCalledOnce();
+  });
+
+  it('dispatches extension hooks in installation order before legacy hooks', () => {
+    const calls: string[] = [];
+    const ExtendedWindow = Window.with(
+      extension('first', () => ({
+        createElement: () => calls.push('first'),
+      })),
+      extension('second', () => ({
+        createElement: () => calls.push('second'),
+      })),
+    );
+    const window = new ExtendedWindow();
+
+    window[HOOKS].createElement = () => calls.push('legacy');
+    window.document.createElement('element');
+
+    expect(calls).toEqual(['first', 'second', 'legacy']);
+  });
+
+  it('resolves legacy hooks assigned after construction', () => {
+    const extensionHook = vi.fn();
+    const legacyHook = vi.fn();
+    const ExtendedWindow = Window.with(
+      extension('extension', () => ({insertChild: extensionHook})),
+    );
+    const window = new ExtendedWindow();
+    const parent = window.document.createElement('parent');
+    const child = window.document.createElement('child');
+
+    window[HOOKS].insertChild = legacyHook;
+    parent.appendChild(child);
+
+    expect(extensionHook).toHaveBeenCalledOnce();
+    expect(legacyHook).toHaveBeenCalledOnce();
+  });
+
+  it('creates independent subscriptions for each Window instance', () => {
+    const subscriptionCounts: Array<() => number> = [];
+    const ExtendedWindow = Window.with(
+      extension('stateful', () => {
+        let count = 0;
+        subscriptionCounts.push(() => count);
+
+        return {
+          setText: () => count++,
+        };
+      }),
+    );
+    const firstWindow = new ExtendedWindow();
+    new ExtendedWindow();
+
+    firstWindow.document.createTextNode('').data = 'updated';
+
+    expect(subscriptionCounts.map((readCount) => readCount())).toEqual([1, 0]);
+  });
+
+  it('supports extensions that only install APIs', () => {
+    class CustomMutationObserver {}
+
+    const ExtendedWindow = Window.with(
+      extension('mutation-observer', (window) => {
+        window.MutationObserver = CustomMutationObserver;
+      }),
+    );
+    const window = new ExtendedWindow();
+
+    expect(window.MutationObserver).toBe(CustomMutationObserver);
+  });
+});
+
+function extension(
+  name: string,
+  install: WindowExtension['install'],
+): WindowExtension {
+  return {name, install};
+}

--- a/packages/polyfill/source/tests/extensions.test.ts
+++ b/packages/polyfill/source/tests/extensions.test.ts
@@ -1,19 +1,18 @@
 import {describe, expect, it, vi} from 'vitest';
 
 import {HOOKS} from '../constants.ts';
-import type {WindowExtension} from '../extensions.ts';
 import type {Hooks} from '../hooks.ts';
 import {Window} from '../Window.ts';
 
 describe('Window extensions', () => {
   it('creates reusable Window subclasses', () => {
     const installs: string[] = [];
-    const first = extension('first', () => {
+    const first = () => {
       installs.push('first');
-    });
-    const second = extension('second', () => {
+    };
+    const second = () => {
       installs.push('second');
-    });
+    };
     const ExtendedWindow = Window.with(first, second);
 
     const firstWindow = new ExtendedWindow();
@@ -26,34 +25,16 @@ describe('Window extensions', () => {
 
   it('composes extensions across successive calls to with()', () => {
     const installs: string[] = [];
-    const FirstWindow = Window.with(
-      extension('first', () => {
-        installs.push('first');
-      }),
-    );
-    const ExtendedWindow = FirstWindow.with(
-      extension('second', () => {
-        installs.push('second');
-      }),
-    );
+    const FirstWindow = Window.with(() => {
+      installs.push('first');
+    });
+    const ExtendedWindow = FirstWindow.with(() => {
+      installs.push('second');
+    });
 
     new ExtendedWindow();
 
     expect(installs).toEqual(['first', 'second']);
-  });
-
-  it('rejects duplicate extension names', () => {
-    const first = extension('duplicate', () => {});
-    const duplicate = extension('duplicate', () => {});
-    const ExtendedWindow = Window.with(first, duplicate);
-    const ChainedWindow = Window.with(first).with(duplicate);
-
-    expect(() => new ExtendedWindow()).toThrow(
-      'An extension named "duplicate" is already installed on this window.',
-    );
-    expect(() => new ChainedWindow()).toThrow(
-      'An extension named "duplicate" is already installed on this window.',
-    );
   });
 
   it('dispatches DOM operations to installed hook subscriptions', () => {
@@ -68,7 +49,7 @@ describe('Window extensions', () => {
       addEventListener: vi.fn<Hooks['addEventListener']>(),
       removeEventListener: vi.fn<Hooks['removeEventListener']>(),
     } satisfies Hooks;
-    const ExtendedWindow = Window.with(extension('hooks', () => hooks));
+    const ExtendedWindow = Window.with(() => hooks);
     const window = new ExtendedWindow();
 
     const parent = window.document.createElement('parent');
@@ -98,12 +79,12 @@ describe('Window extensions', () => {
   it('dispatches extension hooks in installation order before legacy hooks', () => {
     const calls: string[] = [];
     const ExtendedWindow = Window.with(
-      extension('first', () => ({
+      () => ({
         createElement: () => calls.push('first'),
-      })),
-      extension('second', () => ({
+      }),
+      () => ({
         createElement: () => calls.push('second'),
-      })),
+      }),
     );
     const window = new ExtendedWindow();
 
@@ -116,9 +97,9 @@ describe('Window extensions', () => {
   it('resolves legacy hooks assigned after construction', () => {
     const extensionHook = vi.fn();
     const legacyHook = vi.fn();
-    const ExtendedWindow = Window.with(
-      extension('extension', () => ({insertChild: extensionHook})),
-    );
+    const ExtendedWindow = Window.with(() => ({
+      insertChild: extensionHook,
+    }));
     const window = new ExtendedWindow();
     const parent = window.document.createElement('parent');
     const child = window.document.createElement('child');
@@ -132,16 +113,14 @@ describe('Window extensions', () => {
 
   it('creates independent subscriptions for each Window instance', () => {
     const subscriptionCounts: Array<() => number> = [];
-    const ExtendedWindow = Window.with(
-      extension('stateful', () => {
-        let count = 0;
-        subscriptionCounts.push(() => count);
+    const ExtendedWindow = Window.with(() => {
+      let count = 0;
+      subscriptionCounts.push(() => count);
 
-        return {
-          setText: () => count++,
-        };
-      }),
-    );
+      return {
+        setText: () => count++,
+      };
+    });
     const firstWindow = new ExtendedWindow();
     new ExtendedWindow();
 
@@ -153,20 +132,11 @@ describe('Window extensions', () => {
   it('supports extensions that only install APIs', () => {
     class CustomMutationObserver {}
 
-    const ExtendedWindow = Window.with(
-      extension('mutation-observer', (window) => {
-        window.MutationObserver = CustomMutationObserver;
-      }),
-    );
+    const ExtendedWindow = Window.with((window) => {
+      window.MutationObserver = CustomMutationObserver;
+    });
     const window = new ExtendedWindow();
 
     expect(window.MutationObserver).toBe(CustomMutationObserver);
   });
 });
-
-function extension(
-  name: string,
-  install: WindowExtension['install'],
-): WindowExtension {
-  return {name, install};
-}

--- a/packages/polyfill/source/tests/extensions.test.ts
+++ b/packages/polyfill/source/tests/extensions.test.ts
@@ -139,4 +139,20 @@ describe('Window extensions', () => {
 
     expect(window.MutationObserver).toBe(CustomMutationObserver);
   });
+
+  it('lets later extensions override window APIs set by earlier ones', () => {
+    class FirstMutationObserver {}
+    class SecondMutationObserver {}
+
+    const ExtendedWindow = Window.with(
+      (window) => {
+        window.MutationObserver = FirstMutationObserver;
+      },
+      (window) => {
+        window.MutationObserver = SecondMutationObserver;
+      },
+    );
+
+    expect(new ExtendedWindow().MutationObserver).toBe(SecondMutationObserver);
+  });
 });


### PR DESCRIPTION
### TL;DR

Add a composable extension API to `@remote-dom/polyfill`.

`Window.with(...extensions)` creates a reusable `Window` subclass without changing the zero-argument `Window` constructor. Each extension is a function that runs once per window during construction and can return hooks that subscribe to DOM operations:

```ts
const ExtendedWindow = Window.with(
  mutationObserverExtension,
  cssomExtension,
);

const window = new ExtendedWindow();
```

Window API assignments are plain property writes, so later extensions can override APIs installed by earlier ones. Extension hooks are additive and run in installation order. The existing `window[HOOKS]` API is now documented as the legacy integration path; it remains supported and runs after extension hooks.

### What changed?

Extensions are plain functions:

```ts
type WindowExtension = (window: Window) => Partial<Hooks> | void;
```

The function has two distinct scopes:

- The function body runs once per `Window` instance, during construction. It receives the window and can install or replace DOM APIs on it, such as a `MutationObserver` implementation, while keeping state in a closure scoped to that window. If the window is later installed with `Window.setGlobal()`, those APIs become globals.
- The returned hooks run for the lifetime of the window. They subscribe to runtime operations like `createElement`, `setAttribute`, and `insertChild`, and are called each time the corresponding operation happens. Returning hooks is optional when an extension only needs construction-time setup.

These parts compose differently. Window API assignments are last-write-wins. Hooks are additive and dispatched per window in installation order, including across chained `.with()` calls.

The existing low-level API is unchanged:

```ts
window[HOOKS].createElement = (element) => {
  // ...
};
```

Legacy hooks are resolved at dispatch time and run after extension hooks, so existing integrations like `@remote-dom/core/polyfill` continue to work without changes. The polyfill README documents the extension API, its two scopes, these composition rules, and the legacy status of `window[HOOKS]`.

### Why make this change?

The existing `window[HOOKS]` API gives each DOM operation a single mutable callback. Composing integrations requires every consumer to preserve and invoke the previous callback:

```ts
const previous = window[HOOKS].createElement;

window[HOOKS].createElement = (element, namespace) => {
  previous?.(element, namespace);

  // Handle the operation.
};
```

This is powerful, but fragile:

- forgetting to preserve the previous hook silently disables it;
- installation order changes behavior;
- every consumer must implement the same chaining protocol correctly;
- consumers need additional bookkeeping to associate hook state with individual windows.

Even our first-party `@remote-dom/core` integration assigns hooks directly, so another integration assigning the same operation can replace it.

The extension API moves composition into the polyfill. Extensions no longer need to know about each other or cooperate through manual callback chaining. It also separates two related responsibilities cleanly: the function body extends the available DOM APIs at construction time, while its return value subscribes to runtime DOM operations.

Returning a specialized constructor also keeps `new Window()` DOM-shaped and zero-argument:

```ts
const ExtendedWindow = Window.with(extension1, extension2);
const window = new ExtendedWindow();
```

### What this unlocks

This provides a foundation for optional DOM capabilities without growing the base polyfill for every use case:

- a complete `MutationObserver` implementation;
- CSSOM APIs such as `CSSStyleDeclaration` and `Element#style`;
- framework compatibility extensions like the CSSOM shims currently installed by `@remote-dom/react`;
- custom renderers, synchronization layers, instrumentation, and other hook consumers that can coexist safely;
- independently published polyfill extensions;
- eventually expressing the `@remote-dom/core` synchronization hooks as a regular extension.

Each extended `Window` remains reusable, while every instance receives independent installation state.

### What’s deliberately not included?

This PR establishes the extension and composition model. It does not yet:

- migrate `@remote-dom/core` to an extension;
- implement a complete `MutationObserver`;
- add late installation through `window.use()`;
- define uninstall or window-disposal semantics;
- expose creation hooks for the initial `html`, `head`, and `body`.

Extensions run after the base window and its initial document are constructed. This gives each extension a fully initialized window and matches the existing behavior of `window[HOOKS]`, which also does not observe document bootstrap.

### Changes since initial review

- Simplified extensions from `{name, install()}` objects to plain functions.
- Removed name-based duplicate detection; window APIs are last-write-wins, while hooks are additive.
- Switched the hook dispatcher from arrow closures to bound functions.
- Documented construction-time setup, runtime subscriptions, composition rules, and `window[HOOKS]` as legacy.
- Rebased onto `main`, preserving its `EVENT_PHASE_*` constants alongside extension hook dispatch.

### Testing

- Added coverage for reusable and chained extended constructors.
- Covered every existing DOM hook operation.
- Covered deterministic ordering and legacy `window[HOOKS]` compatibility.
- Covered independent per-window state, API-only extensions, and later extensions overriding APIs installed by earlier ones.
- Full test suite, type-checking, linting, bundle-size checks, Playwright E2E tests, and Web Platform Tests pass in CI.
- Included a minor changeset for `@remote-dom/polyfill`.
