### PR TITLE
Improve WPT runner ergonomics

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint": "prettier --check --cache .",
     "test": "vitest",
     "test:wpt": "pnpm --filter @remote-dom/wpt-runner wpt",
+    "wpt": "pnpm --filter @remote-dom/wpt-runner wpt",
     "wpt:prepare": "pnpm --filter @remote-dom/wpt-runner wpt:prepare",
     "wpt:dev": "pnpm --filter @remote-dom/wpt-runner dev",
     "wpt:format": "pnpm --filter @remote-dom/wpt-runner format:capabilities",

--- a/packages/wpt-runner/index.html
+++ b/packages/wpt-runner/index.html
@@ -26,10 +26,12 @@
           <span>WPT path</span>
           <input
             id="path"
+            list="capability-paths"
             value="__runner__/runner-smoke.html?runner=smoke"
             spellcheck="false"
             required
           />
+          <datalist id="capability-paths"></datalist>
         </label>
         <button type="submit">Run test</button>
       </form>

--- a/packages/wpt-runner/src/main.ts
+++ b/packages/wpt-runner/src/main.ts
@@ -3,6 +3,7 @@ import {executeWorker} from './run-worker.ts';
 import type {WptHarnessResult, WptRunRecord} from './types.ts';
 import './style.css';
 
+declare const __WPT_CAPABILITY_PATHS__: readonly string[];
 declare const __WPT_ROOT__: string;
 
 declare global {
@@ -13,6 +14,7 @@ declare global {
 
 const elements = {
   controls: requireElement<HTMLFormElement>('controls'),
+  capabilityPaths: requireElement<HTMLDataListElement>('capability-paths'),
   path: requireElement<HTMLInputElement>('path'),
   status: requireElement<HTMLPreElement>('status'),
   result: requireElement<HTMLPreElement>('result'),
@@ -29,6 +31,13 @@ interface RunSession {
 
 let activeRun: RunSession | undefined;
 window.__WPT_RUN_TEST__ = runWptTest;
+if (typeof __WPT_CAPABILITY_PATHS__ !== 'undefined') {
+  for (const path of __WPT_CAPABILITY_PATHS__) {
+    const option = document.createElement('option');
+    option.value = path;
+    elements.capabilityPaths.append(option);
+  }
+}
 elements.status.textContent = `WPT root: ${__WPT_ROOT__}`;
 
 const parameters = new URLSearchParams(location.search);

--- a/packages/wpt-runner/vite.config.ts
+++ b/packages/wpt-runner/vite.config.ts
@@ -3,8 +3,15 @@ import type {ServerResponse} from 'node:http';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {defineConfig, type Plugin, type UserConfig} from 'vite';
+import {parseCapabilities, rowsByPath} from './scripts/capabilities.ts';
 
 const packageRoot = path.dirname(fileURLToPath(import.meta.url));
+const capabilitiesPath = path.join(packageRoot, 'capabilities.tsv');
+const capabilityPaths = [
+  ...rowsByPath(
+    parseCapabilities(fs.readFileSync(capabilitiesPath, 'utf8')),
+  ).keys(),
+];
 const fixtureRoot = path.join(packageRoot, 'fixtures');
 const wptRoot = process.env.WPT_ROOT
   ? path.resolve(process.env.WPT_ROOT)
@@ -146,6 +153,7 @@ const config: UserConfig = defineConfig({
     },
   },
   define: {
+    __WPT_CAPABILITY_PATHS__: JSON.stringify(capabilityPaths),
     __WPT_ROOT__: JSON.stringify(wptRoot ?? 'not prepared'),
   },
 });


### PR DESCRIPTION
## Summary

- add a root `pnpm wpt` command for invoking the WPT CLI
- suggest the unique test paths from `capabilities.tsv` in the interactive runner
- continue allowing arbitrary WPT paths and gracefully handle an unavailable capability list

## Testing

- `pnpm wpt -- --help`
- `pnpm exec vitest run --project wpt-runner`
- `pnpm type-check`
- `pnpm lint`
- `pnpm --dir packages/wpt-runner exec vite build`
- manually verified the capability suggestions and custom path input in Chromium