### PR TITLE
Fix event listener registration semantics

### DIFF
--- a/.changeset/fair-listeners-register.md
+++ b/.changeset/fair-listeners-register.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/polyfill': patch
+---
+
+Correct event listener identity and AbortSignal handling in the EventTarget polyfill.

--- a/packages/polyfill/source/Event.ts
+++ b/packages/polyfill/source/Event.ts
@@ -13,8 +13,6 @@ export const EVENT_PHASE_BUBBLING = 3;
 
 export type EventPhase = number;
 
-export const CAPTURE_MARKER = '@';
-
 export interface EventInit {
   bubbles?: boolean;
   cancelable?: boolean;
@@ -107,9 +105,9 @@ export function fireEvent(
   phase: typeof EVENT_PHASE_BUBBLING | typeof EVENT_PHASE_CAPTURING,
 ): void {
   const listeners = currentTarget[LISTENERS];
-  const list = listeners?.get(
-    `${event.type}${phase === EVENT_PHASE_CAPTURING ? CAPTURE_MARKER : ''}`,
-  );
+  const list = listeners?.get(event.type)?.[
+    phase === EVENT_PHASE_CAPTURING ? 'capture' : 'bubble'
+  ];
 
   if (!list) return;
 

--- a/packages/polyfill/source/EventTarget.ts
+++ b/packages/polyfill/source/EventTarget.ts
@@ -4,19 +4,39 @@ import {
   EVENT_PHASE_CAPTURING,
   fireEvent,
 } from './Event.ts';
-import {CAPTURE_MARKER, type Event} from './Event.ts';
+import {type Event} from './Event.ts';
 import type {ChildNode} from './ChildNode.ts';
 import type {Document} from './Document.ts';
 
-const ONCE_LISTENERS = Symbol('onceListeners');
+const LISTENER_REGISTRATIONS = Symbol('listenerRegistrations');
+
+type ListenerPhase = 'bubble' | 'capture';
+
+interface EventListenersForType {
+  bubble?: Set<EventListenerOrEventListenerObject>;
+  capture?: Set<EventListenerOrEventListenerObject>;
+}
+
+interface ListenerRegistrationsForType {
+  bubble?: Map<EventListenerOrEventListenerObject, ListenerRegistration>;
+  capture?: Map<EventListenerOrEventListenerObject, ListenerRegistration>;
+}
+
+interface ListenerRegistration {
+  type: string;
+  listener: EventListenerOrEventListenerObject;
+  capture: boolean;
+  once: boolean;
+  normalizedListener: EventListenerOrEventListenerObject;
+  signal?: AbortSignal;
+  abortListener?: EventListener;
+}
 
 export class EventTarget {
-  [LISTENERS]:
-    | Map<string, Set<EventListenerOrEventListenerObject>>
-    | undefined = undefined;
+  [LISTENERS]: Map<string, EventListenersForType> | undefined = undefined;
 
-  [ONCE_LISTENERS]:
-    | WeakMap<EventListenerOrEventListenerObject, EventListener>
+  [LISTENER_REGISTRATIONS]:
+    | Map<string, ListenerRegistrationsForType>
     | undefined = undefined;
 
   /**
@@ -32,31 +52,59 @@ export class EventTarget {
   ) {
     if (listener == null) return;
 
-    const capture = options === true || (options && options.capture === true);
+    const capture =
+      options === true ||
+      (typeof options === 'object' && options.capture === true);
     const once = typeof options === 'object' && options.once === true;
     const signal = typeof options === 'object' ? options.signal : undefined;
-    const key = `${type}${capture ? CAPTURE_MARKER : ''}`;
-    let normalizedListener = listener;
+    if (signal?.aborted) return;
 
-    if (once) {
-      normalizedListener = function normalizedListener(
+    const phase = listenerPhase(capture);
+    let registrations = this[LISTENER_REGISTRATIONS];
+    if (!registrations) {
+      registrations = new Map();
+      this[LISTENER_REGISTRATIONS] = registrations;
+    }
+
+    let registrationsForType = registrations.get(type);
+    if (!registrationsForType) {
+      registrationsForType = {};
+      registrations.set(type, registrationsForType);
+    }
+
+    let registrationsForPhase = registrationsForType[phase];
+    if (!registrationsForPhase) {
+      registrationsForPhase = new Map();
+      registrationsForType[phase] = registrationsForPhase;
+    }
+
+    if (registrationsForPhase.has(listener)) return;
+
+    const target = this;
+    const registration: ListenerRegistration = {
+      type,
+      listener,
+      capture,
+      once,
+      normalizedListener: listener,
+      signal,
+    };
+
+    if (once || signal) {
+      registration.normalizedListener = function normalizedListener(
         this: EventTarget,
         ...args: Parameters<EventListener>
       ) {
-        this.removeEventListener(type, listener, options);
+        if (registration.signal?.aborted) {
+          removeListenerRegistration(target, registration);
+          return;
+        }
+        if (registration.once) removeListenerRegistration(target, registration);
 
         return typeof listener === 'object'
           ? listener.handleEvent(...args)
           : listener.call(this, ...args);
       };
-
-      let onceListeners = this[ONCE_LISTENERS];
-      if (!onceListeners) {
-        onceListeners = new WeakMap();
-        this[ONCE_LISTENERS] = onceListeners;
-      }
-
-      onceListeners.set(listener, normalizedListener);
     }
 
     let listeners = this[LISTENERS];
@@ -65,23 +113,28 @@ export class EventTarget {
       this[LISTENERS] = listeners;
     }
 
-    let list = listeners.get(key);
-    if (!list) {
-      list = new Set();
-      listeners.set(key, list);
+    let listenersForType = listeners.get(type);
+    if (!listenersForType) {
+      listenersForType = {};
+      listeners.set(type, listenersForType);
     }
 
-    if (list.has(normalizedListener)) return;
+    let list = listenersForType[phase];
+    if (!list) {
+      list = new Set();
+      listenersForType[phase] = list;
+    }
 
-    signal?.addEventListener(
-      'abort',
-      () => {
-        removeEventListener.call(this, type, listener, options);
-      },
-      {once: true},
-    );
+    registrationsForPhase.set(listener, registration);
+    list.add(registration.normalizedListener);
 
-    list.add(normalizedListener);
+    if (signal) {
+      const abortListener = () => {
+        removeListenerRegistration(target, registration);
+      };
+      registration.abortListener = abortListener;
+      signal.addEventListener('abort', abortListener, {once: true});
+    }
     this[OWNER_DOCUMENT]?.defaultView[HOOKS_DISPATCH].addEventListener?.(
       this as any,
       type,
@@ -141,24 +194,64 @@ function removeEventListener(
 ) {
   if (listener == null) return;
 
-  const onceListeners = this[ONCE_LISTENERS];
-  const normalizedListener = onceListeners?.get(listener) ?? listener;
-
-  onceListeners?.delete(listener);
-
   const capture = options === true || (options && options.capture === true);
-  const key = `${type}${capture ? CAPTURE_MARKER : ''}`;
-  const list = this[LISTENERS]?.get(key);
+  const phase = listenerPhase(Boolean(capture));
+  const registration =
+    this[LISTENER_REGISTRATIONS]?.get(type)?.[phase]?.get(listener);
+  if (!registration) return;
 
-  if (list) {
-    const deleted = list.delete(normalizedListener);
-    if (deleted) {
-      this[OWNER_DOCUMENT]?.defaultView[HOOKS_DISPATCH].removeEventListener?.(
-        this as any,
-        type,
-        listener,
-        options,
-      );
-    }
+  removeListenerRegistration(this, registration);
+}
+
+function listenerPhase(capture: boolean): ListenerPhase {
+  return capture ? 'capture' : 'bubble';
+}
+
+function removeListenerRegistration(
+  target: EventTarget,
+  registration: ListenerRegistration,
+) {
+  const phase = listenerPhase(registration.capture);
+  const registrations = target[LISTENER_REGISTRATIONS];
+  const registrationsForType = registrations?.get(registration.type);
+  if (!registrationsForType) return;
+
+  const registrationsForPhase = registrationsForType[phase];
+  if (
+    !registrationsForPhase ||
+    registrationsForPhase.get(registration.listener) !== registration
+  ) {
+    return;
   }
+
+  registrationsForPhase.delete(registration.listener);
+  if (registrationsForPhase.size === 0) delete registrationsForType[phase];
+  if (!registrationsForType.bubble && !registrationsForType.capture) {
+    registrations?.delete(registration.type);
+  }
+
+  if (registration.signal && registration.abortListener) {
+    registration.signal.removeEventListener(
+      'abort',
+      registration.abortListener,
+    );
+  }
+
+  const listeners = target[LISTENERS];
+  const listenersForType = listeners?.get(registration.type);
+  if (!listenersForType) return;
+
+  const list = listenersForType[phase];
+  if (!list?.delete(registration.normalizedListener)) return;
+  if (list.size === 0) delete listenersForType[phase];
+  if (!listenersForType.bubble && !listenersForType.capture) {
+    listeners?.delete(registration.type);
+  }
+
+  target[OWNER_DOCUMENT]?.defaultView[HOOKS_DISPATCH].removeEventListener?.(
+    target as any,
+    registration.type,
+    registration.listener,
+    registration.capture,
+  );
 }

--- a/packages/polyfill/source/tests/event-target.test.ts
+++ b/packages/polyfill/source/tests/event-target.test.ts
@@ -1,0 +1,208 @@
+import {describe, expect, it, vi} from 'vitest';
+
+import {Event} from '../Event.ts';
+import {EventTarget} from '../EventTarget.ts';
+
+describe('EventTarget listener registration', () => {
+  it('deduplicates listeners by type, callback, and capture', () => {
+    const target = new EventTarget();
+    const listener = vi.fn();
+
+    target.addEventListener('change', listener);
+    target.addEventListener('change', listener, false);
+    target.addEventListener('change', listener, {capture: false});
+
+    target.dispatchEvent(new Event('change'));
+
+    expect(listener).toHaveBeenCalledOnce();
+  });
+
+  it('treats capture and non-capture registrations as distinct', () => {
+    const target = new EventTarget();
+    const listener = vi.fn();
+
+    target.addEventListener('change', listener);
+    target.addEventListener('change', listener, true);
+    target.removeEventListener('change', listener, false);
+
+    target.dispatchEvent(new Event('change'));
+    expect(listener).toHaveBeenCalledOnce();
+
+    target.removeEventListener('change', listener, true);
+    target.dispatchEvent(new Event('change'));
+    expect(listener).toHaveBeenCalledOnce();
+  });
+
+  it('keeps colliding event names in separate capture lists', () => {
+    const target = new EventTarget();
+    const nameListener = vi.fn();
+    const nameWithMarkerListener = vi.fn();
+
+    target.addEventListener('name', nameListener, true);
+    target.addEventListener('name@', nameWithMarkerListener);
+
+    target.dispatchEvent(new Event('name'));
+    expect(nameListener).toHaveBeenCalledOnce();
+    expect(nameWithMarkerListener).not.toHaveBeenCalled();
+
+    target.dispatchEvent(new Event('name@'));
+    expect(nameListener).toHaveBeenCalledOnce();
+    expect(nameWithMarkerListener).toHaveBeenCalledOnce();
+  });
+
+  it('removes colliding event names by type and capture', () => {
+    const target = new EventTarget();
+    const listener = vi.fn();
+
+    target.addEventListener('name', listener, true);
+    target.addEventListener('name@', listener);
+
+    target.removeEventListener('name', listener, false);
+    target.removeEventListener('name@', listener, true);
+    target.dispatchEvent(new Event('name'));
+    target.dispatchEvent(new Event('name@'));
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    listener.mockClear();
+    target.removeEventListener('name', listener, true);
+    target.dispatchEvent(new Event('name@'));
+    expect(listener).toHaveBeenCalledOnce();
+
+    target.removeEventListener('name@', listener);
+    target.dispatchEvent(new Event('name@'));
+    expect(listener).toHaveBeenCalledOnce();
+  });
+
+  it('does not orphan a once listener when removing the wrong capture mode', () => {
+    const target = new EventTarget();
+    const listener = vi.fn();
+
+    target.addEventListener('change', listener, {once: true});
+    target.removeEventListener('change', listener, true);
+    target.removeEventListener('change', listener);
+
+    target.dispatchEvent(new Event('change'));
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('keeps once listeners distinct across event types', () => {
+    const target = new EventTarget();
+    const listener = vi.fn((event: globalThis.Event) => event.type);
+
+    target.addEventListener('start', listener, {once: true});
+    target.addEventListener('finish', listener, {once: true});
+
+    target.dispatchEvent(new Event('start'));
+    target.dispatchEvent(new Event('start'));
+    target.dispatchEvent(new Event('finish'));
+    target.dispatchEvent(new Event('finish'));
+
+    expect(listener.mock.results.map(({value}) => value)).toEqual([
+      'start',
+      'finish',
+    ]);
+  });
+
+  it('deduplicates once listeners and removes them after dispatch', () => {
+    const target = new EventTarget();
+    const listener = vi.fn();
+
+    target.addEventListener('change', listener, {once: true});
+    target.addEventListener('change', listener, {once: true});
+
+    target.dispatchEvent(new Event('change'));
+    target.dispatchEvent(new Event('change'));
+
+    expect(listener).toHaveBeenCalledOnce();
+  });
+
+  it('uses the registered capture value when removing a once listener', () => {
+    const target = new EventTarget();
+    const listener = vi.fn();
+    const options = {capture: false, once: true};
+
+    target.addEventListener('change', listener, options);
+    options.capture = true;
+
+    target.dispatchEvent(new Event('change'));
+    target.dispatchEvent(new Event('change'));
+
+    expect(listener).toHaveBeenCalledOnce();
+  });
+
+  it('does not register a listener with an already-aborted signal', () => {
+    const target = new EventTarget();
+    const listener = vi.fn();
+    const controller = new AbortController();
+    controller.abort();
+
+    target.addEventListener('change', listener, {
+      signal: controller.signal,
+    });
+    target.dispatchEvent(new Event('change'));
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('removes a registered listener when its signal aborts', () => {
+    const target = new EventTarget();
+    const listener = vi.fn();
+    const controller = new AbortController();
+
+    target.addEventListener('change', listener, {
+      signal: controller.signal,
+    });
+    target.dispatchEvent(new Event('change'));
+    controller.abort();
+    target.dispatchEvent(new Event('change'));
+
+    expect(listener).toHaveBeenCalledOnce();
+  });
+
+  it('uses the registered capture value when a signal removes a listener', () => {
+    const target = new EventTarget();
+    const listener = vi.fn();
+    const controller = new AbortController();
+    const options = {capture: false, signal: controller.signal};
+
+    target.addEventListener('change', listener, options);
+    options.capture = true;
+    controller.abort();
+    target.dispatchEvent(new Event('change'));
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('does not invoke a signal listener during an earlier abort handler', () => {
+    const target = new EventTarget();
+    const listener = vi.fn();
+    const controller = new AbortController();
+
+    controller.signal.addEventListener('abort', () => {
+      target.dispatchEvent(new Event('change'));
+    });
+    target.addEventListener('change', listener, {signal: controller.signal});
+
+    controller.abort();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('does not let an old signal remove a later registration', () => {
+    const target = new EventTarget();
+    const listener = vi.fn();
+    const controller = new AbortController();
+
+    target.addEventListener('change', listener, {
+      signal: controller.signal,
+    });
+    target.removeEventListener('change', listener);
+    target.addEventListener('change', listener);
+
+    controller.abort();
+    target.dispatchEvent(new Event('change'));
+
+    expect(listener).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Problem

`EventTarget` tracked listener registrations in a way that could conflate event types and capture modes, and it did not retain enough registration-specific state to remove `once` listeners and `AbortSignal`-bound listeners reliably. Duplicate registrations could run more than once; an already-aborted signal could still register a listener; and removal through the wrong capture mode could orphan a once wrapper.

## Impact

**Important.** Event handlers are part of the polyfill’s public DOM surface. Incorrect listener identity can duplicate application work or leave callbacks active after callers explicitly remove or abort them, which makes worker-side event behavior diverge from the browser contract.

## Reproduction

```ts
const target = new EventTarget();
const listener = vi.fn();

target.addEventListener('change', listener, {once: true});
target.removeEventListener('change', listener, true);
target.removeEventListener('change', listener);
target.dispatchEvent(new Event('change'));
```

Before this change, the wrong-capture removal could make the once wrapper unremovable, so the final dispatch invoked `listener`. It now invokes no listener. The regression tests also show that the same callback is deduplicated by type, callback, and capture; that once registrations remain distinct across event types; and that already-aborted signals do not register listeners while a later abort removes an active one.

## Change

Store registrations per event type and per capture/bubble phase, keyed by the original callback. Each registration retains its normalized callback and, where applicable, its abort handler. Removal now operates on that exact registration, allowing `once` and signal cleanup to use the capture value recorded at registration time. Listener dispatch reads the corresponding structured type/phase list, avoiding the previous event-name key collision.

## Tests

`packages/polyfill/source/tests/event-target.test.ts` adds regression coverage for duplicate registration, separate capture registrations, colliding event names, once-listener identity and removal, already-aborted and active `AbortSignal` lifecycles, mutated options objects, and stale abort handlers after a listener is re-registered.

## Stack

- Stack: **Events** (#695), layer 1 of 3
- Base: `main`
- This is the bottom of its stack.

## Validation

Fresh GitHub CI on restacked head `e249e3e` passes:

- lint;
- type-check and build;
- unit tests with coverage;
- bundle-size checks;
- Playwright end-to-end tests;
- the classified Web Platform Test suite.
