### PR TITLE
Install DOM globals consistently across repeated installs

### DIFF
--- a/.changeset/fresh-globals-install.md
+++ b/.changeset/fresh-globals-install.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/polyfill': patch
+---
+
+Install missing event methods and error handlers consistently without replacing native global event delivery.

--- a/packages/polyfill/source/Window.ts
+++ b/packages/polyfill/source/Window.ts
@@ -34,6 +34,100 @@ type OnErrorHandler =
     ) => void)
   | null;
 
+const EVENT_HANDLER_PROPERTIES = ['onerror', 'onunhandledrejection'] as const;
+const POLYFILL_GLOBAL_PROPERTY = Symbol.for(
+  '@remote-dom/polyfill/global-property',
+);
+
+type PropertyDescriptors = Record<PropertyKey, PropertyDescriptor>;
+
+function windowPropertyDescriptors(window: Window): PropertyDescriptors {
+  return Object.getOwnPropertyDescriptors(window);
+}
+
+function eventTargetPropertyDescriptors(window: Window): PropertyDescriptors {
+  const properties: PropertyDescriptors = {};
+
+  for (const [property, descriptor] of Object.entries(
+    Object.getOwnPropertyDescriptors(EventTarget.prototype),
+  )) {
+    if (property !== 'constructor' && typeof descriptor.value === 'function') {
+      descriptor.value = markPolyfillGlobalProperty(
+        descriptor.value.bind(window),
+      );
+      properties[property] = descriptor;
+    }
+  }
+
+  return properties;
+}
+
+function eventHandlerPropertyDescriptors(window: Window): PropertyDescriptors {
+  const properties: PropertyDescriptors = {};
+
+  for (const property of EVENT_HANDLER_PROPERTIES) {
+    properties[property] = {
+      configurable: true,
+      enumerable: true,
+      get: markPolyfillGlobalProperty(() => window[property]),
+      set: markPolyfillGlobalProperty((handler) => {
+        window[property] = handler as any;
+      }),
+    };
+  }
+
+  return properties;
+}
+
+function globalPropertyDescriptors(window: Window): PropertyDescriptors {
+  return Object.assign(
+    windowPropertyDescriptors(window),
+    eventTargetPropertyDescriptors(window),
+    eventHandlerPropertyDescriptors(window),
+  );
+}
+
+function markPolyfillGlobalProperty<
+  FunctionType extends (...args: any[]) => any,
+>(value: FunctionType) {
+  Object.defineProperty(value, POLYFILL_GLOBAL_PROPERTY, {value: true});
+  return value;
+}
+
+function installMissingGlobalProperties(
+  target: object,
+  properties: PropertyDescriptors,
+) {
+  for (const property of Reflect.ownKeys(properties)) {
+    const currentDescriptor = findPropertyDescriptor(target, property);
+    if (
+      currentDescriptor == null ||
+      isPolyfillGlobalProperty(currentDescriptor)
+    ) {
+      Object.defineProperty(target, property, properties[property]!);
+    }
+  }
+}
+
+function findPropertyDescriptor(target: object, property: PropertyKey) {
+  let currentTarget: object | null = target;
+
+  while (currentTarget) {
+    const descriptor = Object.getOwnPropertyDescriptor(currentTarget, property);
+    if (descriptor) return descriptor;
+    currentTarget = Object.getPrototypeOf(currentTarget);
+  }
+
+  return undefined;
+}
+
+function isPolyfillGlobalProperty(descriptor: PropertyDescriptor) {
+  return [descriptor.value, descriptor.get, descriptor.set].some(
+    (value) =>
+      typeof value === 'function' && value[POLYFILL_GLOBAL_PROPERTY] === true,
+  );
+}
+
 export class Window extends EventTarget {
   [HOOKS]: Partial<Hooks> = {};
   [EXTENSIONS]: Partial<Hooks>[] = [];
@@ -142,24 +236,35 @@ export class Window extends EventTarget {
   }
 
   static setGlobal(window: Window) {
-    const properties = Object.getOwnPropertyDescriptors(window);
+    const currentSelf = globalThis.self;
+    const currentWindow = globalThis.window;
+    const properties = windowPropertyDescriptors(window);
+    const missingProperties = Object.assign(
+      eventTargetPropertyDescriptors(window),
+      eventHandlerPropertyDescriptors(window),
+    );
 
-    delete (properties as any).self;
+    delete properties.self;
 
     Object.defineProperties(globalThis, properties);
+    installMissingGlobalProperties(globalThis, missingProperties);
 
-    if (typeof globalThis.self === 'undefined') {
+    if (
+      typeof currentSelf === 'undefined' ||
+      (currentSelf === currentWindow && currentSelf !== globalThis)
+    ) {
       Object.defineProperty(globalThis, 'self', {
         value: window,
         configurable: true,
         writable: true,
         enumerable: true,
       });
-    } else {
+    } else if (currentSelf !== globalThis) {
       // There can already be a `self`, like when polyfilling the DOM
       // in a Web Worker. In those cases, just mirror all the `Window`
       // properties onto `self`, rather than wholly redefining it.
-      Object.defineProperties(self, properties);
+      Object.defineProperties(currentSelf, properties);
+      installMissingGlobalProperties(currentSelf, missingProperties);
     }
   }
 
@@ -170,19 +275,7 @@ export class Window extends EventTarget {
       }
     }
 
-    const properties = Object.getOwnPropertyDescriptors(window);
-    const eventTargetPrototypeProperties = Object.getOwnPropertyDescriptors(
-      EventTarget.prototype,
-    );
-
-    for (const descriptor of Object.values(eventTargetPrototypeProperties)) {
-      if (typeof descriptor.value === 'function') {
-        descriptor.value = descriptor.value.bind(window);
-      }
-    }
-
-    Object.defineProperties(globalThis, properties);
-    Object.defineProperties(globalThis, eventTargetPrototypeProperties);
+    Object.defineProperties(globalThis, globalPropertyDescriptors(window));
   }
 }
 

--- a/packages/polyfill/source/tests/window-set-global.test.ts
+++ b/packages/polyfill/source/tests/window-set-global.test.ts
@@ -1,0 +1,321 @@
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {HOOKS} from '../constants.ts';
+import {ErrorEvent} from '../ErrorEvent.ts';
+import {Event} from '../Event.ts';
+import {PromiseRejectionEvent} from '../PromiseRejectionEvent.ts';
+import {Window} from '../Window.ts';
+
+const originalGlobalProperties = Object.getOwnPropertyDescriptors(globalThis);
+
+afterEach(() => {
+  for (const property of Reflect.ownKeys(globalThis)) {
+    if (
+      !Object.prototype.hasOwnProperty.call(originalGlobalProperties, property)
+    ) {
+      Reflect.deleteProperty(globalThis, property);
+    }
+  }
+
+  Object.defineProperties(globalThis, originalGlobalProperties);
+});
+
+function expectCompleteEventTarget(target: any, window: Window) {
+  const listener = vi.fn();
+  target.addEventListener('test', listener);
+  target.dispatchEvent(new Event('test'));
+  expect(listener).toHaveBeenCalledOnce();
+
+  target.removeEventListener('test', listener);
+  target.dispatchEvent(new Event('test'));
+  expect(listener).toHaveBeenCalledOnce();
+
+  const errorHandler = vi.fn();
+  target.onerror = errorHandler;
+  expect(target.onerror).toBe(errorHandler);
+  expect(window.onerror).toBe(errorHandler);
+
+  target.dispatchEvent(new ErrorEvent('error', {message: 'test'}));
+  expect(errorHandler).toHaveBeenCalledOnce();
+
+  const rejectionHandler = vi.fn();
+  target.onunhandledrejection = rejectionHandler;
+  expect(target.onunhandledrejection).toBe(rejectionHandler);
+  expect(window.onunhandledrejection).toBe(rejectionHandler);
+
+  target.dispatchEvent(
+    new PromiseRejectionEvent('unhandledrejection', {
+      promise: Promise.resolve(),
+      reason: new Error('test'),
+    }),
+  );
+  expect(rejectionHandler).toHaveBeenCalledOnce();
+}
+
+describe('Window global installation', () => {
+  describe('setGlobal()', () => {
+    it('installs and reinstalls all globals when self does not exist', () => {
+      delete (globalThis as any).self;
+
+      const firstWindow = new Window();
+      const firstDocument = firstWindow.document;
+      Window.setGlobal(firstWindow);
+
+      expect(globalThis.window).toBe(firstWindow);
+      expect(globalThis.self).toBe(firstWindow);
+      expectCompleteEventTarget(globalThis, firstWindow);
+
+      const secondWindow = new Window();
+      Window.setGlobal(secondWindow);
+
+      expect(globalThis.window).toBe(secondWindow);
+      expect(globalThis.self).toBe(secondWindow);
+      expect(globalThis.document).toBe(secondWindow.document);
+      expectCompleteEventTarget(globalThis, secondWindow);
+
+      expect(firstWindow.window).toBe(firstWindow);
+      expect(firstWindow.self).toBe(firstWindow);
+      expect(firstWindow.document).toBe(firstDocument);
+    });
+
+    it('preserves and updates an existing self across installations', () => {
+      const existingSelf = {} as any;
+      Object.defineProperty(globalThis, 'self', {
+        configurable: true,
+        value: existingSelf,
+        writable: true,
+      });
+
+      const firstWindow = new Window();
+      Window.setGlobal(firstWindow);
+
+      expect(globalThis.self).toBe(existingSelf);
+      expect(existingSelf.window).toBe(firstWindow);
+      expect(existingSelf.document).toBe(firstWindow.document);
+      expectCompleteEventTarget(existingSelf, firstWindow);
+
+      const secondWindow = new Window();
+      Window.setGlobal(secondWindow);
+
+      expect(globalThis.self).toBe(existingSelf);
+      expect(existingSelf.window).toBe(secondWindow);
+      expect(existingSelf.document).toBe(secondWindow.document);
+      expectCompleteEventTarget(existingSelf, secondWindow);
+      expectCompleteEventTarget(globalThis, secondWindow);
+    });
+
+    it('preserves native event properties on global and worker targets', () => {
+      const globalAddEventListener = vi.fn();
+      const globalRemoveEventListener = vi.fn();
+      const globalDispatchEvent = vi.fn();
+      let globalOnerror: unknown = null;
+      let globalOnunhandledrejection: unknown = null;
+
+      Object.defineProperties(globalThis, {
+        addEventListener: {
+          configurable: true,
+          value: globalAddEventListener,
+        },
+        removeEventListener: {
+          configurable: true,
+          value: globalRemoveEventListener,
+        },
+        dispatchEvent: {configurable: true, value: globalDispatchEvent},
+        onerror: {
+          configurable: true,
+          get: () => globalOnerror,
+          set: (handler) => {
+            globalOnerror = handler;
+          },
+        },
+        onunhandledrejection: {
+          configurable: true,
+          get: () => globalOnunhandledrejection,
+          set: (handler) => {
+            globalOnunhandledrejection = handler;
+          },
+        },
+      });
+
+      const workerAddEventListener = vi.fn();
+      const workerRemoveEventListener = vi.fn();
+      const workerDispatchEvent = vi.fn();
+      let workerOnerror: unknown = null;
+      let workerOnunhandledrejection: unknown = null;
+      const workerPrototype = {};
+
+      Object.defineProperties(workerPrototype, {
+        addEventListener: {
+          configurable: true,
+          value: workerAddEventListener,
+        },
+        removeEventListener: {
+          configurable: true,
+          value: workerRemoveEventListener,
+        },
+        dispatchEvent: {configurable: true, value: workerDispatchEvent},
+        onerror: {
+          configurable: true,
+          get: () => workerOnerror,
+          set: (handler) => {
+            workerOnerror = handler;
+          },
+        },
+        onunhandledrejection: {
+          configurable: true,
+          get: () => workerOnunhandledrejection,
+          set: (handler) => {
+            workerOnunhandledrejection = handler;
+          },
+        },
+      });
+
+      const workerSelf = Object.create(workerPrototype);
+      Object.defineProperty(globalThis, 'self', {
+        configurable: true,
+        value: workerSelf,
+        writable: true,
+      });
+
+      const firstWindow = new Window();
+      Window.setGlobal(firstWindow);
+
+      expect(globalThis.addEventListener).toBe(globalAddEventListener);
+      expect(globalThis.removeEventListener).toBe(globalRemoveEventListener);
+      expect(globalThis.dispatchEvent).toBe(globalDispatchEvent);
+      expect(workerSelf.addEventListener).toBe(workerAddEventListener);
+      expect(workerSelf.removeEventListener).toBe(workerRemoveEventListener);
+      expect(workerSelf.dispatchEvent).toBe(workerDispatchEvent);
+
+      for (const property of [
+        'addEventListener',
+        'removeEventListener',
+        'dispatchEvent',
+        'onerror',
+        'onunhandledrejection',
+      ]) {
+        expect(Object.hasOwn(workerSelf, property)).toBe(false);
+      }
+
+      const globalListener = vi.fn();
+      globalThis.addEventListener('message', globalListener);
+      globalThis.removeEventListener('message', globalListener);
+      (globalThis.dispatchEvent as any)(new Event('message'));
+      expect(globalAddEventListener).toHaveBeenCalledWith(
+        'message',
+        globalListener,
+      );
+      expect(globalRemoveEventListener).toHaveBeenCalledWith(
+        'message',
+        globalListener,
+      );
+      expect(globalDispatchEvent).toHaveBeenCalledOnce();
+
+      const workerListener = vi.fn();
+      workerSelf.addEventListener('message', workerListener);
+      workerSelf.removeEventListener('message', workerListener);
+      workerSelf.dispatchEvent(new Event('message'));
+      expect(workerAddEventListener).toHaveBeenCalledWith(
+        'message',
+        workerListener,
+      );
+      expect(workerRemoveEventListener).toHaveBeenCalledWith(
+        'message',
+        workerListener,
+      );
+      expect(workerDispatchEvent).toHaveBeenCalledOnce();
+
+      const globalErrorHandler = vi.fn();
+      const workerErrorHandler = vi.fn();
+      (globalThis as any).onerror = globalErrorHandler;
+      workerSelf.onerror = workerErrorHandler;
+      expect(globalOnerror).toBe(globalErrorHandler);
+      expect(workerOnerror).toBe(workerErrorHandler);
+      expect(firstWindow.onerror).toBe(null);
+
+      const globalRejectionHandler = vi.fn();
+      const workerRejectionHandler = vi.fn();
+      (globalThis as any).onunhandledrejection = globalRejectionHandler;
+      workerSelf.onunhandledrejection = workerRejectionHandler;
+      expect(globalOnunhandledrejection).toBe(globalRejectionHandler);
+      expect(workerOnunhandledrejection).toBe(workerRejectionHandler);
+      expect(firstWindow.onunhandledrejection).toBe(null);
+
+      const secondWindow = new Window();
+      Window.setGlobal(secondWindow);
+
+      expect(globalThis.addEventListener).toBe(globalAddEventListener);
+      expect(workerSelf.addEventListener).toBe(workerAddEventListener);
+      expect(workerSelf.document).toBe(secondWindow.document);
+    });
+
+    it('reinstalls globals from a distinct Window module copy', async () => {
+      delete (globalThis as any).self;
+      vi.resetModules();
+      const {Window: FirstWindow} = await import('../Window.ts');
+      vi.resetModules();
+      const {Window: SecondWindow} = await import('../Window.ts');
+
+      expect(SecondWindow).not.toBe(FirstWindow);
+
+      const firstWindow = new FirstWindow();
+      const firstDocument = firstWindow.document;
+      FirstWindow.setGlobal(firstWindow);
+
+      const secondWindow = new SecondWindow();
+      SecondWindow.setGlobal(secondWindow);
+
+      expect(globalThis.window).toBe(secondWindow);
+      expect(globalThis.self).toBe(secondWindow);
+      expect(globalThis.document).toBe(secondWindow.document);
+      expect(firstWindow.window).toBe(firstWindow);
+      expect(firstWindow.self).toBe(firstWindow);
+      expect(firstWindow.document).toBe(firstDocument);
+
+      const listener = vi.fn();
+      globalThis.addEventListener('test', listener);
+      secondWindow.dispatchEvent(new secondWindow.Event('test'));
+      expect(listener).toHaveBeenCalledOnce();
+
+      const errorHandler = vi.fn();
+      globalThis.onerror = errorHandler;
+      expect(secondWindow.onerror).toBe(errorHandler);
+      expect(firstWindow.onerror).toBe(null);
+    });
+  });
+
+  describe('setGlobalThis()', () => {
+    it('installs and reinstalls the same complete global surface', () => {
+      const existingSelf = {};
+      Object.defineProperty(globalThis, 'self', {
+        configurable: true,
+        value: existingSelf,
+        writable: true,
+      });
+
+      const firstWindow = new Window();
+      Window.setGlobalThis(firstWindow);
+
+      expect(globalThis.window).toBe(globalThis);
+      expect(globalThis.self).toBe(globalThis);
+      expectCompleteEventTarget(globalThis, firstWindow);
+
+      const secondWindow = new Window();
+      Window.setGlobalThis(secondWindow);
+
+      expect(globalThis.window).toBe(globalThis);
+      expect(globalThis.self).toBe(globalThis);
+      expect(globalThis.document).toBe(secondWindow.document);
+      expectCompleteEventTarget(globalThis, secondWindow);
+    });
+  });
+
+  it('installs symbol-keyed Window state', () => {
+    Window.setGlobal(new Window());
+    expect(Object.hasOwn(globalThis, HOOKS)).toBe(true);
+  });
+
+  it('cleans symbol-keyed Window state between tests', () => {
+    expect(Object.hasOwn(globalThis, HOOKS)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

`Window.setGlobal()` treated a previously installed polyfill `self` like an external worker target on a later installation. Reinstalling could therefore mirror the next window’s properties onto the old polyfill `Window` while leaving `globalThis.self` stale. `setGlobal()` also did not supply the same bound `EventTarget` methods and error-handler accessors as `setGlobalThis()`.

## Impact

**Important.** Repeated DOM installation can leave globals pointing at one `Window` while mutating another, causing document and event state to be read from the wrong polyfill instance. In worker-like environments, an incomplete or inconsistent installed global surface can also break consumers that rely on event methods or `onerror`/`onunhandledrejection`.

## Reproduction

```ts
delete (globalThis as any).self;

const firstWindow = new Window();
Window.setGlobal(firstWindow);

const secondWindow = new Window();
Window.setGlobal(secondWindow);
```

Before this change, the second installation could leave `globalThis.self` referring to `firstWindow` and overwrite properties on that original window. It now makes both `globalThis.window` and `globalThis.self` refer to `secondWindow`, while leaving the first window’s own document and self references intact. When `self` is an existing worker-like object, the tests instead preserve that target and update its polyfill properties on each installation.

## Change

Build explicit descriptor sets for Window properties, bound `EventTarget` methods, and the implemented error-handler accessors. Mark installed fallback event methods and error-handler accessors so later installations can replace those fallbacks without overwriting native target members. `setGlobal()` now distinguishes an external `self` from a prior polyfill `Window`, and both installation APIs use the same complete polyfill additions.

## Tests

`packages/polyfill/source/tests/window-set-global.test.ts` covers initial and repeated installation with no `self`, with an existing worker-like `self`, and from distinct `Window` module copies. It verifies complete event and error-handler behavior, preservation of native event properties, `setGlobalThis()` reinstalls, symbol-keyed Window state, and test cleanup.

## Stack

- Stack: **Globals and custom-element registry** (#707), layer 1 of 2
- Base: `main`
- This is the bottom of its stack.

This branch is now based directly on `main`; superseded PR #665 is no longer part of the stack.

## Validation

Fresh GitHub CI on restacked head `072b7e8` passes:

- lint;
- type-check and build;
- unit tests with coverage;
- bundle-size checks;
- Playwright end-to-end tests;
- the classified Web Platform Test suite.
