### PR TITLE
Fix Node.contains ancestor traversal

### DIFF
--- a/.changeset/tidy-node-contains.md
+++ b/.changeset/tidy-node-contains.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/polyfill': patch
+---
+
+Fix `Node.contains()` for nested descendants and nodes outside the current subtree.

--- a/packages/polyfill/source/Node.ts
+++ b/packages/polyfill/source/Node.ts
@@ -159,10 +159,11 @@ export class Node extends EventTarget {
   contains(node: Node | null) {
     let currentNode: Node | null = node;
 
-    while (true) {
-      if (currentNode == null) return false;
+    while (currentNode != null) {
       if (currentNode === this) return true;
-      currentNode = node!.parentNode;
+      currentNode = currentNode.parentNode;
     }
+
+    return false;
   }
 }

--- a/packages/polyfill/source/tests/node.test.ts
+++ b/packages/polyfill/source/tests/node.test.ts
@@ -1,0 +1,56 @@
+import {Window} from '../index.ts';
+
+import {beforeEach, describe, expect, it} from 'vitest';
+
+beforeEach(() => {
+  const window = new Window();
+  Window.setGlobalThis(window);
+});
+
+describe('Node.contains', () => {
+  it('returns true for itself', () => {
+    const element = document.createElement('div');
+
+    expect(element.contains(element)).toBe(true);
+  });
+
+  it('returns true for a direct child', () => {
+    const parent = document.createElement('div');
+    const child = document.createElement('span');
+    parent.appendChild(child);
+
+    expect(parent.contains(child)).toBe(true);
+  });
+
+  it('returns true for a deep descendant', () => {
+    const parent = document.createElement('div');
+    const child = document.createElement('span');
+    const grandchild = document.createElement('em');
+    parent.appendChild(child);
+    child.appendChild(grandchild);
+
+    expect(parent.contains(grandchild)).toBe(true);
+  });
+
+  it('returns false for a node in another subtree', () => {
+    const parent = document.createElement('div');
+    const otherParent = document.createElement('div');
+    const otherChild = document.createElement('span');
+    otherParent.appendChild(otherChild);
+
+    expect(parent.contains(otherChild)).toBe(false);
+  });
+
+  it('returns false for a detached node', () => {
+    const parent = document.createElement('div');
+    const detached = document.createElement('span');
+
+    expect(parent.contains(detached)).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    const parent = document.createElement('div');
+
+    expect(parent.contains(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

`Node.contains()` is supposed to walk from the candidate node toward the root until it finds the receiver. The previous loop repeatedly read the original candidate’s parent instead of advancing from the current node, so it stopped making progress after the first hop.

As a result, checks such as `parent.contains(grandchild)` and checks against a node in another attached subtree never returned.

## Impact

**Critical.** This is a synchronous infinite loop. Because the polyfill is intended for non-browser environments such as Web Workers, one affected `contains()` call can block that worker’s event loop indefinitely instead of returning a boolean.

## Reproduction

```ts
const parent = document.createElement('div');
const child = document.createElement('span');
const grandchild = document.createElement('em');

parent.appendChild(child);
child.appendChild(grandchild);

parent.contains(grandchild);
```

Before this change, the final call never returned. It now returns `true`. The equivalent check against a node in another subtree now terminates and returns `false`.

## Change

Advance through `currentNode.parentNode` on each iteration and return `false` after reaching the root. This preserves the expected results for the receiver itself and direct children while allowing deeper and unrelated-node checks to terminate.

## Tests

Regression coverage verifies the receiver itself, a direct child, a deep descendant, a node in another subtree, a detached node, and `null`. The deep-descendant and other-subtree cases exercise the paths that previously hung.

## Stack

- Stack: **Independent quick wins** (#702), layer 1 of 4
- Base: `main`
- This is the bottom of its stack.

Coverage includes both the explicit detached-node case and a node attached to another subtree.

## Validation

Fresh GitHub CI on restacked head `3c57e5b` passes:

- lint;
- type-check and build;
- unit tests with coverage;
- bundle-size checks;
- Playwright end-to-end tests;
- the classified Web Platform Test suite.
