### PR TITLE
Default CustomEvent detail to null when omitted

### DIFF
--- a/.changeset/grumpy-cycles-suffer.md
+++ b/.changeset/grumpy-cycles-suffer.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/polyfill': patch
+---
+
+Default omitted CustomEvent detail values to null.

--- a/packages/polyfill/source/CustomEvent.ts
+++ b/packages/polyfill/source/CustomEvent.ts
@@ -10,7 +10,7 @@ export class CustomEvent<T = any> extends Event {
 
   constructor(type: string, eventInitDict?: CustomEventInit<T>) {
     super(type, eventInitDict);
-    this.detail = eventInitDict?.detail as any;
+    this.detail = (eventInitDict?.detail ?? null) as any;
   }
 
   /**
@@ -25,6 +25,6 @@ export class CustomEvent<T = any> extends Event {
     detail?: T,
   ) {
     super.initEvent(type, bubbles, cancelable);
-    (this as any).detail = detail;
+    (this as any).detail = detail ?? null;
   }
 }

--- a/packages/polyfill/source/tests/custom-event.test.ts
+++ b/packages/polyfill/source/tests/custom-event.test.ts
@@ -1,0 +1,26 @@
+import {describe, expect, it} from 'vitest';
+
+import {CustomEvent} from '../CustomEvent.ts';
+
+describe('CustomEvent', () => {
+  describe('constructor', () => {
+    it('defaults detail to null when the initialization dictionary is omitted', () => {
+      expect(new CustomEvent('test').detail).toBeNull();
+    });
+
+    it('defaults detail to null when omitted from the initialization dictionary', () => {
+      expect(new CustomEvent('test', {}).detail).toBeNull();
+    });
+
+    it('defaults an explicitly undefined detail to null', () => {
+      expect(new CustomEvent('test', {detail: undefined}).detail).toBeNull();
+    });
+
+    it.each([null, 0, false, '', {custom: 'detail'}])(
+      'preserves an explicitly supplied detail value of %j',
+      (detail) => {
+        expect(new CustomEvent('test', {detail}).detail).toBe(detail);
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`CustomEvent.detail` was assigned directly from the optional initialization dictionary. Constructing a `CustomEvent` without a `detail` property therefore exposed `undefined`, whereas the event’s default detail value is `null`.

## Impact

**Minor.** Consumers that distinguish an omitted payload from an explicitly supplied value can observe the wrong public event contract. In the worker polyfill, that makes `CustomEvent` behave differently from the DOM API it models.

## Reproduction

```ts
new CustomEvent('change').detail;
new CustomEvent('change', {}).detail;
```

Before this change, both expressions evaluated to `undefined`. They now evaluate to `null`. The regression test also shows that explicitly supplied `null`, `0`, `false`, `''`, and object values are preserved; an explicitly `undefined` `detail` is normalized to `null` by this implementation.

## Change

Normalize the constructor’s `detail` value to `null` when it is nullish. The same normalization is applied by the legacy `initCustomEvent()` path so both ways of creating a custom event expose the same default.

## Tests

Adds focused constructor coverage for an omitted initialization dictionary, a dictionary without `detail`, explicit `undefined`, and explicitly supplied falsy and object values.

## Stack

- Stack: **Independent quick wins** (#702), layer 2 of 4
- Base: `fix-node-contains`
- Review after PR #688.

## Validation

Fresh GitHub CI on restacked head `5f0b228` passes:

- lint;
- type-check and build;
- unit tests with coverage;
- bundle-size checks;
- Playwright end-to-end tests;
- the classified Web Platform Test suite.
