### PR TITLE
Normalize createTextNode hook data

### DIFF
--- a/.changeset/normalize-text-node-hooks.md
+++ b/.changeset/normalize-text-node-hooks.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/polyfill': patch
+---
+
+Normalize `createTextNode()` hook data to match the created text node.

--- a/packages/polyfill/source/Document.ts
+++ b/packages/polyfill/source/Document.ts
@@ -66,7 +66,7 @@ export class Document extends ParentNode {
 
   createTextNode(data: any) {
     const text = createNode(new Text(data), this);
-    this[HOOKS].createText?.(text as any, String(data));
+    this[HOOKS].createText?.(text as any, text.data);
     return text;
   }
 

--- a/packages/polyfill/source/tests/create-text-node.test.ts
+++ b/packages/polyfill/source/tests/create-text-node.test.ts
@@ -1,0 +1,38 @@
+import {HOOKS, Window} from '../index.ts';
+
+import {expect, it} from 'vitest';
+
+function expectCreateTextNodeHookData(data: any, expected: string) {
+  const window = new Window();
+  Window.setGlobalThis(window);
+
+  let hookText: unknown;
+  let hookData: string | undefined;
+
+  window[HOOKS].createText = (text, data) => {
+    hookText = text;
+    hookData = data;
+  };
+
+  const text = document.createTextNode(data);
+
+  expect(text.data).toBe(expected);
+  expect(hookText).toBe(text);
+  expect(hookData).toBe(text.data);
+}
+
+it('normalizes null createTextNode hook data', () => {
+  expectCreateTextNodeHookData(null, '');
+});
+
+it('normalizes undefined createTextNode hook data', () => {
+  expectCreateTextNodeHookData(undefined, '');
+});
+
+it('preserves empty createTextNode hook data', () => {
+  expectCreateTextNodeHookData('', '');
+});
+
+it('preserves ordinary createTextNode hook data', () => {
+  expectCreateTextNodeHookData('Hello, world!', 'Hello, world!');
+});


### PR DESCRIPTION
## Problem

`Document.createTextNode()` normalized nullish input in the `Text` node constructor, but passed `String(data)` to the `createText` hook. As a result, the local node and the Remote DOM hook described different text for the same operation.

## Impact

**Minor.** Creating a text node with `null` or `undefined` stored `''` locally while emitting `'null'` or `'undefined'` to the hook. A remote receiver could therefore render text that did not exist in the worker’s local DOM.

## Reproduction

```ts
window[HOOKS].createText = (_text, data) => console.log(data);

const text = document.createTextNode(null);

text.data; // ''
```

Before this change, the hook logged `'null'` even though `text.data` was `''`; `undefined` had the equivalent mismatch. It now receives `text.data`, so both values are `''`. Empty and ordinary strings continue to reach the hook unchanged.

## Change

Pass the newly created node’s normalized `data` property to `createText` rather than independently coercing the original argument. This makes the hook payload use the same single normalization result as local `CharacterData`.

## Tests

Adds focused hook assertions for `null`, `undefined`, `''`, and an ordinary string. Each test verifies the stored text data, the node passed to the hook, and the hook payload agree.

## Stack

- Stack: **Independent quick wins** (#702), layer 3 of 4
- Base: `default-custom-event-detail`
- Review after PR #689.

## Validation

Fresh GitHub CI on restacked head `e1acf97` passes:

- lint;
- type-check and build;
- unit tests with coverage;
- bundle-size checks;
- Playwright end-to-end tests;
- the classified Web Platform Test suite.
