### PR TITLE
Include Comment nodes in polyfill hook types

### DIFF
--- a/.changeset/include-comment-hook-nodes.md
+++ b/.changeset/include-comment-hook-nodes.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/polyfill': patch
+---
+
+Include `Comment` nodes in the polyfill hook type contract.

--- a/packages/polyfill/source/hooks.ts
+++ b/packages/polyfill/source/hooks.ts
@@ -8,9 +8,17 @@ export interface Hooks {
   ): void;
   removeAttribute(element: Element, name: string, ns?: string | null): void;
   createText(text: Text, data: string): void;
-  setText(text: Text, data: string): void;
-  insertChild(parent: Element, node: Element | Text, index: number): void;
-  removeChild(parent: Element, node: Element | Text, index: number): void;
+  setText(text: Text | Comment, data: string): void;
+  insertChild(
+    parent: Element,
+    node: Element | Text | Comment,
+    index: number,
+  ): void;
+  removeChild(
+    parent: Element,
+    node: Element | Text | Comment,
+    index: number,
+  ): void;
   addEventListener(
     element: EventTarget,
     type: string,

--- a/packages/polyfill/source/tests/hooks.test.ts
+++ b/packages/polyfill/source/tests/hooks.test.ts
@@ -1,0 +1,43 @@
+import {HOOKS, type Hooks, Window} from '../index.ts';
+
+import {expect, expectTypeOf, it, vi} from 'vitest';
+
+type CommentNode = ReturnType<Document['createComment']>;
+type HookParameters<Hook extends (...args: any[]) => unknown> =
+  Parameters<Hook>;
+
+it('types comment creation for handling hooks', () => {
+  expectTypeOf<CommentNode>().toMatchTypeOf<
+    HookParameters<Hooks['setText']>[0]
+  >();
+  expectTypeOf<CommentNode>().toMatchTypeOf<
+    HookParameters<Hooks['insertChild']>[1]
+  >();
+  expectTypeOf<CommentNode>().toMatchTypeOf<
+    HookParameters<Hooks['removeChild']>[1]
+  >();
+});
+
+it('calls handling hooks for comments', () => {
+  const window = new Window();
+  Window.setGlobalThis(window);
+
+  const insertChild = vi.fn();
+  const removeChild = vi.fn();
+  const setText = vi.fn();
+
+  window[HOOKS].insertChild = insertChild;
+  window[HOOKS].removeChild = removeChild;
+  window[HOOKS].setText = setText;
+
+  const parent = document.createElement('div');
+  const comment = document.createComment('Comment');
+
+  parent.appendChild(comment);
+  comment.data = 'Updated comment';
+  parent.removeChild(comment);
+
+  expect(insertChild).toHaveBeenCalledWith(parent, comment, 0);
+  expect(setText).toHaveBeenCalledWith(comment, 'Updated comment');
+  expect(removeChild).toHaveBeenCalledWith(parent, comment, 0);
+});


### PR DESCRIPTION
## Problem

The polyfill invokes text and child-mutation hooks for `Comment` nodes at runtime, but the corresponding `Hooks` TypeScript signatures accepted only `Text` nodes. The public type contract therefore rejected a runtime-supported node kind.

## Impact

**Minor.** TypeScript consumers implementing `setText`, `insertChild`, or `removeChild` could not accurately type their handling of comments. This is type-contract drift rather than a runtime failure, but it can force unsafe casts or make valid hook implementations fail type checking.

## Reproduction

```ts
const comment = document.createComment('Comment');

parent.appendChild(comment);
comment.data = 'Updated comment';
parent.removeChild(comment);
```

The added regression test verifies that runtime calls already pass the `Comment` node to `insertChild`, `setText`, and `removeChild`. Before this change, the type-level assertions that a `Document['createComment']` result is accepted by those hook parameter types failed; they now pass.

## Change

Widen the affected hook parameters from `Text` to `Text | Comment`, matching the nodes the polyfill already supplies at runtime. No hook dispatch behavior changes.

## Tests

Adds compile-time assertions for comment compatibility with all three hook signatures, plus runtime spies that verify insertion, text updates, and removal receive the comment node and expected payloads.

## Stack

- Stack: **Independent quick wins** (#702), layer 4 of 4
- Base: `normalize-text-node-hooks`
- Review after PR #690.

## Validation

Fresh GitHub CI on restacked head `08e3223` passes:

- lint;
- type-check and build;
- unit tests with coverage;
- bundle-size checks;
- Playwright end-to-end tests;
- the classified Web Platform Test suite.
