### PR TITLE
Distinguish DOM mutation and selector errors

### DIFF
--- a/.changeset/distinguish-dom-errors.md
+++ b/.changeset/distinguish-dom-errors.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/polyfill': patch
+---
+
+Throw named DOM errors for invalid tree mutations and selector syntax.

--- a/packages/polyfill/source/ChildNode.ts
+++ b/packages/polyfill/source/ChildNode.ts
@@ -1,5 +1,6 @@
-import {NEXT, PREV} from './constants.ts';
+import {HOST, NEXT, PARENT, PREV} from './constants.ts';
 import {performWithCustomElementReactions} from './custom-element-reactions.ts';
+import {createDOMException} from './dom-exception.ts';
 import type {ParentNode} from './ParentNode.ts';
 import {Node} from './Node.ts';
 
@@ -15,12 +16,13 @@ export class ChildNode extends Node {
     if (!parent) return;
 
     return performWithCustomElementReactions(() => {
-      validateNodesForInsertion(parent, nodes);
+      const staged = stageNodes(nodes);
+      validateInsertionNodes(parent, staged);
 
       let next = this[NEXT];
-      while (next && nodes.includes(next)) next = next[NEXT];
+      while (next && staged.includes(next)) next = next[NEXT];
 
-      const replacement = convertNodesIntoNode(parent, nodes);
+      const replacement = convertNodesIntoNode(parent, staged);
       if (this.parentNode === parent) {
         parent.replaceChild(replacement, this);
       } else {
@@ -34,12 +36,13 @@ export class ChildNode extends Node {
     if (!parent) return;
 
     return performWithCustomElementReactions(() => {
-      validateNodesForInsertion(parent, nodes);
+      const staged = stageNodes(nodes);
+      validateInsertionNodes(parent, staged);
 
       let previous = this[PREV];
-      while (previous && nodes.includes(previous)) previous = previous[PREV];
+      while (previous && staged.includes(previous)) previous = previous[PREV];
 
-      const node = convertNodesIntoNode(parent, nodes);
+      const node = convertNodesIntoNode(parent, staged);
       parent.insertBefore(node, previous ? previous[NEXT] : parent.firstChild);
     });
   }
@@ -49,12 +52,13 @@ export class ChildNode extends Node {
     if (!parent) return;
 
     return performWithCustomElementReactions(() => {
-      validateNodesForInsertion(parent, nodes);
+      const staged = stageNodes(nodes);
+      validateInsertionNodes(parent, staged);
 
       let next = this[NEXT];
-      while (next && nodes.includes(next)) next = next[NEXT];
+      while (next && staged.includes(next)) next = next[NEXT];
 
-      const node = convertNodesIntoNode(parent, nodes);
+      const node = convertNodesIntoNode(parent, staged);
       parent.insertBefore(node, next);
     });
   }
@@ -66,7 +70,11 @@ export function toNode(parent: ParentNode, node: Node | any) {
   return ownerDocument.createTextNode(String(node));
 }
 
-function validateNodesForInsertion(
+export function stageNodes(nodes: (Node | string)[]) {
+  return nodes.map((node) => (node instanceof Node ? node : String(node)));
+}
+
+export function validateInsertionNodes(
   parent: ParentNode,
   nodes: (Node | string)[],
 ) {
@@ -76,11 +84,12 @@ function validateNodesForInsertion(
     let ancestor: Node | null = parent;
     while (ancestor) {
       if (ancestor === node) {
-        throw Error(
-          'cannot insert a node into itself or one of its descendants',
+        throw createDOMException(
+          'Cannot insert a node into itself or one of its descendants',
+          'HierarchyRequestError',
         );
       }
-      ancestor = ancestor.parentNode;
+      ancestor = ancestor[PARENT] ?? ancestor[HOST];
     }
   }
 }

--- a/packages/polyfill/source/CustomElementRegistry.ts
+++ b/packages/polyfill/source/CustomElementRegistry.ts
@@ -1,3 +1,5 @@
+import {createDOMException} from './dom-exception.ts';
+
 const VALID_CUSTOM_ELEMENT_NAME =
   /^[a-z][^A-Z\u0000\t\n\f\r />]*-[^A-Z\u0000\t\n\f\r />]*$/u;
 
@@ -30,21 +32,21 @@ export class CustomElementRegistryImplementation
       !VALID_CUSTOM_ELEMENT_NAME.test(name) ||
       RESERVED_CUSTOM_ELEMENT_NAMES.has(name)
     ) {
-      throw new DOMException(
+      throw createDOMException(
         `Invalid custom element name: "${name}"`,
         'SyntaxError',
       );
     }
 
     if (this.registry.has(name)) {
-      throw new DOMException(
+      throw createDOMException(
         `A custom element named "${name}" has already been defined`,
         'NotSupportedError',
       );
     }
 
     if (this.getName(Constructor) != null) {
-      throw new DOMException(
+      throw createDOMException(
         'This constructor has already been registered in this custom element registry',
         'NotSupportedError',
       );

--- a/packages/polyfill/source/Document.ts
+++ b/packages/polyfill/source/Document.ts
@@ -32,13 +32,13 @@ import {
   adoptNodes,
   cloneNode,
   collectAdoptionSnapshot,
-  createNotSupportedError,
   getElementById as findElementById,
   getElementsByTagName as findElementsByTagName,
 } from './shared.ts';
 import {HTMLBodyElement} from './HTMLBodyElement.ts';
 import {HTMLHeadElement} from './HTMLHeadElement.ts';
 import {HTMLHtmlElement} from './HTMLHtmlElement.ts';
+import {createDOMException} from './dom-exception.ts';
 
 export class Document extends ParentNode {
   nodeType: NodeType = NODE_TYPE_DOCUMENT;
@@ -130,7 +130,10 @@ export class Document extends ParentNode {
 
   importNode(node: Node, deep?: boolean) {
     if (node.nodeType === NODE_TYPE_DOCUMENT) {
-      throw createNotSupportedError('Cannot import a document node');
+      throw createDOMException(
+        'Cannot import a document node',
+        'NotSupportedError',
+      );
     }
 
     return cloneNode(node, deep, this);

--- a/packages/polyfill/source/EventTarget.ts
+++ b/packages/polyfill/source/EventTarget.ts
@@ -6,6 +6,7 @@ import {
   OWNER_DOCUMENT,
   STOP_IMMEDIATE_PROPAGATION,
 } from './constants.ts';
+import {createDOMException} from './dom-exception.ts';
 import {
   EVENT_PHASE_NONE,
   EVENT_PHASE_BUBBLING,
@@ -165,8 +166,9 @@ export class EventTarget {
 
   dispatchEvent(event: Event) {
     if (event[DISPATCHING]) {
-      throw createInvalidStateError(
+      throw createDOMException(
         `Failed to execute 'dispatchEvent' on 'EventTarget': The event is already being dispatched.`,
+        'InvalidStateError',
       );
     }
 
@@ -281,15 +283,4 @@ function removeListenerRegistration(
     registration.listener,
     registration.capture,
   );
-}
-
-function createInvalidStateError(message: string) {
-  const DOMExceptionConstructor = globalThis.DOMException;
-  if (typeof DOMExceptionConstructor === 'function') {
-    return new DOMExceptionConstructor(message, 'InvalidStateError');
-  }
-
-  const error = new Error(message);
-  error.name = 'InvalidStateError';
-  return error;
 }

--- a/packages/polyfill/source/ParentNode.ts
+++ b/packages/polyfill/source/ParentNode.ts
@@ -3,7 +3,6 @@ import {
   NEXT,
   PREV,
   PARENT,
-  HOST,
   OWNER_DOCUMENT,
   NODE_TYPE_DOCUMENT_FRAGMENT,
   NODE_TYPE_ELEMENT,
@@ -12,7 +11,12 @@ import {
 } from './constants.ts';
 import type {Node} from './Node.ts';
 import type {Element} from './Element.ts';
-import {ChildNode, toNode} from './ChildNode.ts';
+import {
+  ChildNode,
+  stageNodes,
+  toNode,
+  validateInsertionNodes,
+} from './ChildNode.ts';
 import {NodeList} from './NodeList.ts';
 import {querySelectorAll, querySelector} from './selectors.ts';
 import {
@@ -26,6 +30,7 @@ import {
   performWithCustomElementReactions,
 } from './custom-element-reactions.ts';
 import {performHookEffects} from './hook-effects.ts';
+import {createDOMException} from './dom-exception.ts';
 
 interface PreparedInsertionRoot {
   node: Node;
@@ -56,36 +61,43 @@ export class ParentNode extends ChildNode {
 
   append(...nodes: (Node | string)[]) {
     return performWithCustomElementReactions(() => {
-      for (const child of nodes) {
-        if (child == null) continue;
-        this.appendChild(toNode(this, child));
-      }
+      const staged = stageNodes(nodes.filter((node) => node != null));
+      validateInsertionNodes(this, staged);
+      for (const child of staged) this.appendChild(toNode(this, child));
     });
   }
 
   prepend(...nodes: (Node | string)[]) {
     return performWithCustomElementReactions(() => {
+      const staged = stageNodes(nodes.filter((node) => node != null));
+      validateInsertionNodes(this, staged);
       const before = this.firstChild;
-      for (const child of nodes) {
-        if (child == null) continue;
+      for (const child of staged)
         this.insertBefore(toNode(this, child), before);
-      }
     });
   }
 
   replaceChildren(...nodes: (Node | string)[]) {
     return performWithCustomElementReactions(() => {
+      const staged = stageNodes(nodes.filter((node) => node != null));
+      validateInsertionNodes(this, staged);
+
       let child;
       while ((child = this.firstChild)) {
         this.removeChild(child);
       }
-      this.append(...nodes);
+      for (const node of staged) this.appendChild(toNode(this, node));
     });
   }
 
   removeChild(child: Node) {
     return performWithCustomElementReactions(() => {
-      if (child.parentNode !== this) throw Error(`not a child of this node`);
+      if (child.parentNode !== this) {
+        throw createDOMException(
+          'The node is not a child of this node',
+          'NotFoundError',
+        );
+      }
 
       const disconnectedNodes = this[IS_CONNECTED]
         ? selfAndDescendants(child)
@@ -109,13 +121,16 @@ export class ParentNode extends ChildNode {
 
   replaceChild(newChild: Node, oldChild: Node) {
     return performWithCustomElementReactions(() => {
+      validateInsertionNodes(this, [newChild]);
       if (oldChild.parentNode !== this) {
-        throw Error('reference node is not a child of this parent');
+        throw createDOMException(
+          'The reference node is not a child of this parent',
+          'NotFoundError',
+        );
       }
       if (newChild === oldChild) return oldChild;
 
       const next = oldChild[NEXT];
-      this.validateInsertion(newChild, next);
 
       const insertion = this.prepareInsertion(newChild);
       const removedNodes = this[IS_CONNECTED]
@@ -167,18 +182,13 @@ export class ParentNode extends ChildNode {
   }
 
   private validateInsertion(child: Node, before: Node | null) {
-    if (before && before.parentNode !== this) {
-      throw Error('reference node is not a child of this parent');
-    }
+    validateInsertionNodes(this, [child]);
 
-    let ancestor: Node | null = this;
-    while (ancestor) {
-      if (ancestor === child) {
-        throw Error(
-          'cannot insert a node into itself or one of its descendants',
-        );
-      }
-      ancestor = ancestor[PARENT] ?? ancestor[HOST];
+    if (before && before.parentNode !== this) {
+      throw createDOMException(
+        'The reference node is not a child of this parent',
+        'NotFoundError',
+      );
     }
   }
 

--- a/packages/polyfill/source/dom-exception.ts
+++ b/packages/polyfill/source/dom-exception.ts
@@ -1,0 +1,14 @@
+export function createDOMException(
+  message: string,
+  name: string,
+): DOMException {
+  const DOMExceptionConstructor = globalThis.DOMException;
+
+  if (typeof DOMExceptionConstructor === 'function') {
+    return new DOMExceptionConstructor(message, name);
+  }
+
+  const error = new Error(message);
+  error.name = name;
+  return error as DOMException;
+}

--- a/packages/polyfill/source/names.ts
+++ b/packages/polyfill/source/names.ts
@@ -3,6 +3,7 @@ import {
   XMLNS_NAMESPACE,
   type NamespaceURI,
 } from './constants.ts';
+import {createDOMException} from './dom-exception.ts';
 
 const VALID_ELEMENT_LOCAL_NAME =
   /^(?:[A-Za-z][^\0\t\n\f\r\u0020/>]*|[:_\u0080-\u{10FFFF}][A-Za-z0-9-.:_\u0080-\u{10FFFF}]*)$/u;
@@ -51,14 +52,14 @@ export function validateAndExtractQualifiedName(
   }
 
   if (prefix != null && namespace == null) {
-    throw new DOMException(
+    throw createDOMException(
       `A namespace is required for the prefix in "${qualifiedName}"`,
       'NamespaceError',
     );
   }
 
   if (prefix === 'xml' && namespace !== XML_NAMESPACE) {
-    throw new DOMException(
+    throw createDOMException(
       `The xml prefix requires the XML namespace`,
       'NamespaceError',
     );
@@ -68,7 +69,7 @@ export function validateAndExtractQualifiedName(
     (qualifiedName === 'xmlns' || prefix === 'xmlns') &&
     namespace !== XMLNS_NAMESPACE
   ) {
-    throw new DOMException(
+    throw createDOMException(
       `The xmlns name requires the XMLNS namespace`,
       'NamespaceError',
     );
@@ -79,7 +80,7 @@ export function validateAndExtractQualifiedName(
     qualifiedName !== 'xmlns' &&
     prefix !== 'xmlns'
   ) {
-    throw new DOMException(
+    throw createDOMException(
       `The XMLNS namespace requires the xmlns name or prefix`,
       'NamespaceError',
     );
@@ -89,5 +90,5 @@ export function validateAndExtractQualifiedName(
 }
 
 function throwInvalidCharacterError(name: string): never {
-  throw new DOMException(`Invalid name: "${name}"`, 'InvalidCharacterError');
+  throw createDOMException(`Invalid name: "${name}"`, 'InvalidCharacterError');
 }

--- a/packages/polyfill/source/selectors.ts
+++ b/packages/polyfill/source/selectors.ts
@@ -8,6 +8,7 @@ import {
 } from './constants.ts';
 import {isElementNode} from './shared.ts';
 import {NodeList} from './NodeList.ts';
+import {createDOMException} from './dom-exception.ts';
 
 import type {Node} from './Node.ts';
 import type {Element} from './Element.ts';
@@ -56,12 +57,13 @@ export interface Matcher {
   value?: string;
 }
 
-const ELEMENT_SELECTOR_TEST = /[a-zA-Z]/;
+const SUPPORTED_IDENTIFIER_TEST =
+  /^(?:--|-?[A-Za-z_\u0080-\u{10FFFF}])[A-Za-z0-9_\u0080-\u{10FFFF}-]*$/u;
 
 function readFunctionArgument(
   selector: string,
   start: number,
-): [string, number] {
+): [string, number] | null {
   let depth = 1;
   let quote: string | null = null;
 
@@ -86,7 +88,14 @@ function readFunctionArgument(
     }
   }
 
-  return [selector.slice(start), selector.length];
+  return null;
+}
+
+function throwSelectorSyntaxError(selector: string): never {
+  throw createDOMException(
+    `Invalid or unsupported selector: "${selector}"`,
+    'SyntaxError',
+  );
 }
 
 export function querySelector(
@@ -128,14 +137,22 @@ export function querySelectorAll(
   return results;
 }
 
-export function parseSelector(selector: string) {
+export function parseSelector(
+  selector: string,
+  allowLeadingCombinator = false,
+) {
   let part: Part = {combinator: COMBINATOR_INNER, matchers: []};
   const parts = [part];
   const tokenizer =
     /\s*?([>\s+~]?)\s*?(?:(?:\[\s*([^\]=\s]+)\s*(?:=\s*(?:(['"])(.*?)\3|([^\]\s]+)))?\s*\])|([#.]?)([^\s#.[>:+~()]+)|:(\w+)(\()?)/gi;
   const normalizedSelector = selector.trim();
+  if (normalizedSelector === '') throwSelectorSyntaxError(selector);
+
+  let consumed = 0;
   let token;
   while ((token = tokenizer.exec(normalizedSelector))) {
+    if (token.index !== consumed) throwSelectorSyntaxError(selector);
+
     // [1]: ancestor/parent/sibling/adjacent
     // [2]: attribute name
     // [4]/[5]: quoted/unquoted attribute value
@@ -144,6 +161,13 @@ export function parseSelector(selector: string) {
     // [8]: :pseudo/:function() name
     // [9]: :function opening parenthesis
     if (token[1]) {
+      if (
+        part.matchers.length === 0 &&
+        !(allowLeadingCombinator && parts.length === 1)
+      ) {
+        throwSelectorSyntaxError(selector);
+      }
+
       // Update the combinator on the (now parent) Part:
       if (token[1] === '>') part.combinator = COMBINATOR_CHILD;
       else if (token[1] === '+') part.combinator = COMBINATOR_ADJACENT;
@@ -154,34 +178,54 @@ export function parseSelector(selector: string) {
       parts.push(part);
     }
 
-    let type: MatcherType = MATCHER_UNKNOWN;
+    let type: MatcherType;
+    const name = token[8] ? asciiLowercase(token[8]) : (token[2] || token[7])!;
     if (token[2]) {
+      if (!SUPPORTED_IDENTIFIER_TEST.test(name)) {
+        throwSelectorSyntaxError(selector);
+      }
+      if (token[5] != null && !SUPPORTED_IDENTIFIER_TEST.test(token[5])) {
+        throwSelectorSyntaxError(selector);
+      }
       type = MATCHER_ATTRIBUTE;
     } else if (token[6]) {
+      if (!SUPPORTED_IDENTIFIER_TEST.test(name)) {
+        throwSelectorSyntaxError(selector);
+      }
       type = token[6] === '#' ? MATCHER_ID : MATCHER_CLASS;
     } else if (token[8]) {
       type = token[9] == null ? MATCHER_PSEUDO : MATCHER_FUNCTION;
-    } else if (token[7]) {
-      if (token[7] === '*') {
-        type = MATCHER_UNKNOWN; // Universal selector matches all
-      } else if (ELEMENT_SELECTOR_TEST.test(token[7])) {
-        type = MATCHER_ELEMENT;
-      }
+    } else if (token[7] === '*') {
+      type = MATCHER_UNKNOWN;
+    } else if (token[7] && SUPPORTED_IDENTIFIER_TEST.test(token[7])) {
+      type = MATCHER_ELEMENT;
+    } else {
+      throwSelectorSyntaxError(selector);
     }
+
     let value = token[4] ?? token[5] ?? token[7];
     if (token[9]) {
-      [value, tokenizer.lastIndex] = readFunctionArgument(
+      const argument = readFunctionArgument(
         normalizedSelector,
         tokenizer.lastIndex,
       );
+      if (argument == null) throwSelectorSyntaxError(selector);
+      [value, tokenizer.lastIndex] = argument;
+
+      if (name !== 'has' && name !== 'not') throwSelectorSyntaxError(selector);
+      parseSelector(value, name === 'has');
+    } else if (type === MATCHER_PSEUDO) {
+      throwSelectorSyntaxError(selector);
     }
-    const name = token[8] ? asciiLowercase(token[8]) : (token[2] || token[7])!;
-    part.matchers.push({
-      type,
-      name,
-      value,
-    });
+
+    part.matchers.push({type, name, value});
+    consumed = tokenizer.lastIndex;
   }
+
+  if (consumed !== normalizedSelector.length || part.matchers.length === 0) {
+    throwSelectorSyntaxError(selector);
+  }
+
   return parts;
 }
 
@@ -193,7 +237,7 @@ function matchesSelector(element: Element, selector: string) {
 }
 
 function matchesRelativeSelector(scope: Element, selector: string) {
-  const parts = parseSelector(selector);
+  const parts = parseSelector(selector, true);
   const first = parts[0]!;
   if (parts.length === 1 && first.matchers.length === 0) return false;
 
@@ -349,7 +393,10 @@ function matchesSelectorMatcher(
     case MATCHER_PSEUDO:
       switch (name) {
         default:
-          throw Error(`Pseudo :${name} not implemented`);
+          throw createDOMException(
+            `Pseudo :${name} is not supported`,
+            'SyntaxError',
+          );
       }
     case MATCHER_FUNCTION:
       switch (name) {
@@ -358,7 +405,10 @@ function matchesSelectorMatcher(
         case 'not':
           return !matchesSelector(element, value || '');
         default:
-          throw Error(`Function :${name}(${value}) not implemented`);
+          throw createDOMException(
+            `Function :${name}(${value}) is not supported`,
+            'SyntaxError',
+          );
       }
   }
   return false;

--- a/packages/polyfill/source/shared.ts
+++ b/packages/polyfill/source/shared.ts
@@ -28,16 +28,7 @@ import type {HTMLTemplateElement} from './HTMLTemplateElement.ts';
 import type {CharacterData} from './CharacterData.ts';
 import type {Text} from './Text.ts';
 import {MATCHER_ID, querySelector} from './selectors.ts';
-
-export function createNotSupportedError(message: string) {
-  if (typeof DOMException === 'function') {
-    return new DOMException(message, 'NotSupportedError');
-  }
-
-  const error = new Error(message);
-  error.name = 'NotSupportedError';
-  return error;
-}
+import {createDOMException} from './dom-exception.ts';
 
 export function isAttributeNode(node: Node): node is Attr {
   return node.nodeType === NODE_TYPE_ATTRIBUTE;
@@ -179,7 +170,10 @@ export function cloneNode(
   document: Document = node.ownerDocument,
 ): Node {
   if (node.nodeType === NODE_TYPE_DOCUMENT) {
-    throw createNotSupportedError('Cannot clone a document node');
+    throw createDOMException(
+      'Cannot clone a document node',
+      'NotSupportedError',
+    );
   }
 
   const cloned = cloneNodeShallow(node, document);

--- a/packages/polyfill/source/tests/dom-mutation-selector-errors.test.ts
+++ b/packages/polyfill/source/tests/dom-mutation-selector-errors.test.ts
@@ -1,0 +1,359 @@
+import {beforeEach, describe, expect, it} from 'vitest';
+
+import {HOOKS, Window} from '../index.ts';
+import {createDOMException} from '../dom-exception.ts';
+import {parseSelector} from '../selectors.ts';
+
+let polyfillWindow: Window;
+
+beforeEach(() => {
+  polyfillWindow = new Window();
+  Window.setGlobalThis(polyfillWindow);
+});
+
+function expectDOMError(operation: () => unknown, name: string) {
+  try {
+    operation();
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toMatchObject({name});
+    return;
+  }
+
+  throw new Error(`Expected ${name}`);
+}
+
+describe('DOM mutation errors', () => {
+  it('reports invalid child and reference nodes as NotFoundError without mutations', () => {
+    const parent = document.createElement('div');
+    const child = document.createElement('span');
+    const foreignParent = document.createElement('section');
+    const foreignChild = document.createElement('em');
+    parent.appendChild(child);
+    foreignParent.appendChild(foreignChild);
+    const mutations: string[] = [];
+    polyfillWindow[HOOKS].insertChild = () => mutations.push('insert');
+    polyfillWindow[HOOKS].removeChild = () => mutations.push('remove');
+
+    expectDOMError(() => parent.removeChild(foreignChild), 'NotFoundError');
+    expectDOMError(
+      () => parent.insertBefore(foreignChild, foreignChild),
+      'NotFoundError',
+    );
+    expectDOMError(
+      () => parent.replaceChild(foreignChild, foreignChild),
+      'NotFoundError',
+    );
+
+    expect([...parent.childNodes]).toEqual([child]);
+    expect([...foreignParent.childNodes]).toEqual([foreignChild]);
+    expect(child.parentNode).toBe(parent);
+    expect(foreignChild.parentNode).toBe(foreignParent);
+    expect(mutations).toEqual([]);
+  });
+
+  it('reports hierarchy violations as HierarchyRequestError without mutations', () => {
+    const ancestor = document.createElement('section');
+    const parent = document.createElement('div');
+    const child = document.createElement('span');
+    ancestor.appendChild(parent);
+    parent.appendChild(child);
+    const mutations: string[] = [];
+    polyfillWindow[HOOKS].insertChild = () => mutations.push('insert');
+    polyfillWindow[HOOKS].removeChild = () => mutations.push('remove');
+
+    expectDOMError(
+      () => parent.replaceChild(ancestor, child),
+      'HierarchyRequestError',
+    );
+
+    expect([...ancestor.childNodes]).toEqual([parent]);
+    expect([...parent.childNodes]).toEqual([child]);
+    expect(parent.parentNode).toBe(ancestor);
+    expect(child.parentNode).toBe(parent);
+    expect(mutations).toEqual([]);
+  });
+
+  it('reports hierarchy errors before invalid reference errors', () => {
+    const parent = document.createElement('div');
+    const child = document.createElement('span');
+    const foreignParent = document.createElement('section');
+    const foreignChild = document.createElement('em');
+    parent.appendChild(child);
+    foreignParent.appendChild(foreignChild);
+    const mutations: string[] = [];
+    polyfillWindow[HOOKS].insertChild = () => mutations.push('insert');
+    polyfillWindow[HOOKS].removeChild = () => mutations.push('remove');
+
+    expectDOMError(
+      () => parent.insertBefore(parent, foreignChild),
+      'HierarchyRequestError',
+    );
+    expectDOMError(
+      () => parent.replaceChild(parent, foreignChild),
+      'HierarchyRequestError',
+    );
+
+    expect([...parent.childNodes]).toEqual([child]);
+    expect([...foreignParent.childNodes]).toEqual([foreignChild]);
+    expect(parent.parentNode).toBeNull();
+    expect(child.parentNode).toBe(parent);
+    expect(foreignChild.parentNode).toBe(foreignParent);
+    expect(mutations).toEqual([]);
+  });
+
+  it('validates host-including hierarchy before references and variadic commits', () => {
+    const sourceWindow = new Window();
+    const sourceDocument = sourceWindow.document;
+    const destinationDocument = polyfillWindow.document;
+    const holder = destinationDocument.createElement('div');
+    const template = destinationDocument.createElement('template');
+    const content = template.content;
+    const foreignParent = destinationDocument.createElement('section');
+    const foreignReference = destinationDocument.createElement('span');
+    const sourceParent = sourceDocument.createElement('div');
+    const movable = sourceDocument.createElement('atomic-host-node');
+    let reactions = 0;
+    (movable as any).connectedCallback = () => reactions++;
+    (movable as any).disconnectedCallback = () => reactions++;
+    holder.appendChild(template);
+    foreignParent.appendChild(foreignReference);
+    sourceDocument.body.appendChild(sourceParent);
+    sourceParent.appendChild(movable);
+    reactions = 0;
+
+    const sourceHooks: string[] = [];
+    const destinationHooks: string[] = [];
+    sourceWindow[HOOKS] = {
+      insertChild: () => sourceHooks.push('insert'),
+      removeChild: () => sourceHooks.push('remove'),
+    };
+    polyfillWindow[HOOKS] = {
+      insertChild: () => destinationHooks.push('insert'),
+      removeChild: () => destinationHooks.push('remove'),
+    };
+
+    expectDOMError(
+      () => content.insertBefore(template, foreignReference),
+      'HierarchyRequestError',
+    );
+    expectDOMError(
+      () => content.append(movable, template),
+      'HierarchyRequestError',
+    );
+
+    expect([...holder.childNodes]).toEqual([template]);
+    expect([...content.childNodes]).toEqual([]);
+    expect([...foreignParent.childNodes]).toEqual([foreignReference]);
+    expect([...sourceParent.childNodes]).toEqual([movable]);
+    expect(template.parentNode).toBe(holder);
+    expect(movable.parentNode).toBe(sourceParent);
+    expect(movable.ownerDocument).toBe(sourceDocument);
+    expect(sourceHooks).toEqual([]);
+    expect(destinationHooks).toEqual([]);
+    expect(reactions).toBe(0);
+  });
+
+  it.each([
+    [
+      'append',
+      (parent: Element, child: Element) => parent.append(child, parent),
+    ],
+    [
+      'prepend',
+      (parent: Element, child: Element) => parent.prepend(child, parent),
+    ],
+    [
+      'replaceChildren',
+      (parent: Element, child: Element) =>
+        parent.replaceChildren(child, parent),
+    ],
+    [
+      'before',
+      (parent: Element, child: Element) =>
+        parent.firstElementChild!.before(child, parent),
+    ],
+    [
+      'after',
+      (parent: Element, child: Element) =>
+        parent.firstElementChild!.after(child, parent),
+    ],
+    [
+      'replaceWith',
+      (parent: Element, child: Element) =>
+        parent.firstElementChild!.replaceWith(child, parent),
+    ],
+  ])('validates every %s argument before changing state', (_name, mutate) => {
+    const parent = document.createElement('div');
+    const existing = document.createElement('span');
+    const source = document.createElement('section');
+    const movable = document.createElement('em');
+    parent.appendChild(existing);
+    source.appendChild(movable);
+    const mutations: string[] = [];
+    polyfillWindow[HOOKS].insertChild = () => mutations.push('insert');
+    polyfillWindow[HOOKS].removeChild = () => mutations.push('remove');
+
+    expectDOMError(() => mutate(parent, movable), 'HierarchyRequestError');
+
+    expect([...parent.childNodes]).toEqual([existing]);
+    expect([...source.childNodes]).toEqual([movable]);
+    expect(existing.parentNode).toBe(parent);
+    expect(movable.parentNode).toBe(source);
+    expect(mutations).toEqual([]);
+  });
+
+  it.each([
+    [
+      'append',
+      (parent: any, child: any, invalid: any) => parent.append(child, invalid),
+    ],
+    [
+      'prepend',
+      (parent: any, child: any, invalid: any) => parent.prepend(child, invalid),
+    ],
+    [
+      'replaceChildren',
+      (parent: any, child: any, invalid: any) =>
+        parent.replaceChildren(child, invalid),
+    ],
+    [
+      'before',
+      (parent: any, child: any, invalid: any) =>
+        parent.firstElementChild!.before(child, invalid),
+    ],
+    [
+      'after',
+      (parent: any, child: any, invalid: any) =>
+        parent.firstElementChild!.after(child, invalid),
+    ],
+    [
+      'replaceWith',
+      (parent: any, child: any, invalid: any) =>
+        parent.firstElementChild!.replaceWith(child, invalid),
+    ],
+  ])(
+    'converts every %s argument before moving cross-document nodes',
+    (_name, mutate) => {
+      const sourceWindow = new Window();
+      const sourceDocument = sourceWindow.document;
+      const destinationDocument = polyfillWindow.document;
+      const sourceParent = sourceDocument.createElement('section');
+      const movable = sourceDocument.createElement('atomic-node');
+      const parent = destinationDocument.createElement('div');
+      const existing = destinationDocument.createElement('span');
+      let reactions = 0;
+      (movable as any).connectedCallback = () => reactions++;
+      (movable as any).disconnectedCallback = () => reactions++;
+      sourceDocument.body.appendChild(sourceParent);
+      sourceParent.appendChild(movable);
+      destinationDocument.body.appendChild(parent);
+      parent.appendChild(existing);
+      reactions = 0;
+
+      const sourceHooks: string[] = [];
+      const destinationHooks: string[] = [];
+      sourceWindow[HOOKS] = {
+        createText: () => sourceHooks.push('createText'),
+        insertChild: () => sourceHooks.push('insert'),
+        removeChild: () => sourceHooks.push('remove'),
+      };
+      polyfillWindow[HOOKS] = {
+        createText: () => destinationHooks.push('createText'),
+        insertChild: () => destinationHooks.push('insert'),
+        removeChild: () => destinationHooks.push('remove'),
+      };
+      const conversionError = new Error('conversion failed');
+      const invalid = {
+        toString() {
+          throw conversionError;
+        },
+      };
+
+      expect(() => mutate(parent, movable, invalid)).toThrow(conversionError);
+
+      expect([...parent.childNodes]).toEqual([existing]);
+      expect([...sourceParent.childNodes]).toEqual([movable]);
+      expect(existing.parentNode).toBe(parent);
+      expect(movable.parentNode).toBe(sourceParent);
+      expect(movable.ownerDocument).toBe(sourceDocument);
+      expect(sourceHooks).toEqual([]);
+      expect(destinationHooks).toEqual([]);
+      expect(reactions).toBe(0);
+    },
+  );
+});
+
+describe('selector syntax errors', () => {
+  it.each([
+    '',
+    '   ',
+    '[data-open',
+    ':has(.item',
+    ':has([title="item])',
+    'div)',
+    'div, span',
+    ':hover',
+    ':HOVER',
+    ':matches(div)',
+    ':has(:hover)',
+    'div >',
+    'div >> span',
+    '[data-kind^=item]',
+  ])('reports malformed or unsupported %j as SyntaxError', (selector) => {
+    const parent = document.createElement('div');
+    parent.appendChild(document.createElement('span'));
+
+    expectDOMError(() => parseSelector(selector), 'SyntaxError');
+    expectDOMError(() => parent.querySelector(selector), 'SyntaxError');
+    expectDOMError(() => parent.querySelectorAll(selector), 'SyntaxError');
+  });
+
+  it.each([
+    '[data-kind="item]',
+    '[data-kind=\'item"]',
+    '[data-kind=item"value]',
+    '[data-kind==item]',
+    '[data-kind="item" junk]',
+    '[data-kind=#item]',
+  ])('reports malformed attribute selector %j as SyntaxError', (attribute) => {
+    const parent = document.createElement('div');
+    parent.appendChild(document.createElement('span'));
+
+    for (const selector of [attribute, `:has(${attribute})`]) {
+      expectDOMError(() => parseSelector(selector), 'SyntaxError');
+      expectDOMError(() => parent.querySelector(selector), 'SyntaxError');
+      expectDOMError(() => parent.querySelectorAll(selector), 'SyntaxError');
+    }
+  });
+});
+
+describe('DOMException fallback', () => {
+  it('creates a named Error when the DOMException global is unavailable', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'DOMException',
+    );
+    Object.defineProperty(globalThis, 'DOMException', {
+      configurable: true,
+      value: undefined,
+      writable: true,
+    });
+
+    try {
+      const error = createDOMException('Invalid tree', 'HierarchyRequestError');
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toMatchObject({
+        message: 'Invalid tree',
+        name: 'HierarchyRequestError',
+      });
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(globalThis, 'DOMException', descriptor);
+      } else {
+        delete (globalThis as {DOMException?: typeof DOMException})
+          .DOMException;
+      }
+    }
+  });
+});

--- a/packages/polyfill/source/tests/selectors.test.ts
+++ b/packages/polyfill/source/tests/selectors.test.ts
@@ -79,14 +79,10 @@ describe('selector parsing and matching', () => {
       });
     });
 
-    it('parses pseudo-class selectors', () => {
-      const parts = parseSelector(':hover');
-      expect(parts).toHaveLength(1);
-      expect(parts[0]!.matchers[0]!).toMatchObject({
-        type: 5, // MatcherType.Pseudo
-        name: 'hover',
-        value: undefined,
-      });
+    it('rejects unsupported pseudo-class selectors', () => {
+      expect(() => parseSelector(':hover')).toThrowError(
+        expect.objectContaining({name: 'SyntaxError'}),
+      );
     });
 
     it('parses function selectors', () => {
@@ -121,7 +117,6 @@ describe('selector parsing and matching', () => {
     it.each([
       [':HAS(div)', 6, 'has', 'div'],
       [':Not(.Hidden)', 6, 'not', '.Hidden'],
-      [':HOVER', 5, 'hover', undefined],
     ])(
       'ASCII-lowercases only the pseudo-class name in %s',
       (selector, type, name, value) => {
@@ -287,6 +282,18 @@ describe('selector parsing and matching', () => {
 
       const hidden = container.querySelector('.hidden');
       expect(hidden?.textContent?.trim()).toBe('Hidden paragraph');
+    });
+
+    it('selects Unicode and double-hyphen identifiers', () => {
+      const article = container.querySelector('article')!;
+      const unicode = document.createElement('span');
+      unicode.setAttribute('class', 'é');
+      unicode.id = '--foo';
+      article.appendChild(unicode);
+
+      expect(container.querySelector('.é')).toBe(unicode);
+      expect(container.querySelector('#--foo')).toBe(unicode);
+      expect(container.querySelector('article:has(> .é)')).toBe(article);
     });
 
     it('selects by attribute', () => {
@@ -493,9 +500,7 @@ describe('selector parsing and matching', () => {
       expect(container.querySelector(selector) != null).toBe(matches);
     });
 
-    it('handles edge cases', () => {
-      expect(container.querySelectorAll('')).toHaveLength(0);
-
+    it('selects all elements with the universal selector', () => {
       const allElements = container.querySelectorAll('*');
       expect(allElements.length).toBeGreaterThan(0);
     });

--- a/packages/size-limit/.size-limit.js
+++ b/packages/size-limit/.size-limit.js
@@ -27,9 +27,9 @@ function bundleCheck(name, fixture, limit) {
 
 export default [
   bundleCheck('@remote-dom/compat', 'compat', '1500 B'),
-  bundleCheck('@remote-dom/core (remote)', 'core-remote', '14000 B'),
+  bundleCheck('@remote-dom/core (remote)', 'core-remote', '17000 B'),
   bundleCheck('@remote-dom/core (host)', 'core-host', '2500 B'),
-  bundleCheck('@remote-dom/polyfill', 'polyfill', '8000 B'),
+  bundleCheck('@remote-dom/polyfill', 'polyfill', '12000 B'),
   bundleCheck('@remote-dom/preact (remote)', 'preact-remote', '1500 B'),
   bundleCheck('@remote-dom/preact (host)', 'preact-host', '2500 B'),
   bundleCheck('@remote-dom/react (remote)', 'react-remote', '2000 B'),


### PR DESCRIPTION
## Problem

The polyfill reported invalid tree mutations with generic `Error` objects and treated some malformed or unsupported selectors as non-matches. Callers could not reliably distinguish a missing child or reference node, a hierarchy violation, and invalid selector syntax from other failures or an ordinary empty result.

## Impact

**Minor.** Code using the exposed DOM-like API cannot make DOM-style error decisions when every mutation failure is a generic error or invalid selector input silently produces no match. Mutation failures also need to report the error before they move nodes or emit Remote DOM hooks, so the local tree and remote receiver remain synchronized.

## Reproduction

```ts
const parent = document.createElement('div');
const foreignParent = document.createElement('section');
const foreignChild = document.createElement('span');
foreignParent.appendChild(foreignChild);

parent.removeChild(foreignChild);
parent.querySelectorAll('');
```

Before this change, the first operation threw a generic `Error`, and the empty selector returned an empty result. They now throw errors named `NotFoundError` and `SyntaxError`, respectively. The regression tests likewise verify `HierarchyRequestError` for an attempted ancestor insertion; in every mutation-error case, parent/child links and insert/remove hook calls remain unchanged.

## Change

- Add a shared DOM-exception factory that returns a named `DOMException` when available and a named `Error` fallback when it is not.
- Report `NotFoundError` for invalid child or reference nodes and `HierarchyRequestError` for invalid insertion hierarchy, with hierarchy validation taking precedence where both conditions apply.
- Stage and validate all arguments to variadic insertion APIs before converting values or moving a cross-document node, preserving state if validation or conversion fails.
- Reject empty, malformed, and unsupported selector syntax with `SyntaxError` rather than silently returning no matches; supported Unicode and double-hyphen identifiers and relative `:has()` selectors remain covered.
- Reuse the shared factory for existing named custom-element, namespace, document-cloning, and event redispatch errors so the fallback behavior is consistent.

## Tests

Adds focused error-contract coverage for invalid children and references, hierarchy violations (including template host relationships), all variadic insertion APIs, and conversion failures after a cross-document node has been staged. The tests assert error names, unchanged links, no hook calls, and no custom-element reactions. Selector coverage exercises malformed/unsupported syntax through the parser, `querySelector()`, and `querySelectorAll()`, and verifies the no-`DOMException` fallback.

## Stack

This draft is the final fan-in for the subsystem stacks. The live PR remains parked on `polyfill-correctness-prerequisites`; its historical head also contains a bundle-size gate update that was separately landed by PR #706. An unpublished maintainer-local reconstruction isolates this error-contract layer on the fully integrated post-#706 base, but it is supporting evidence rather than a reviewable branch. After the prerequisite stacks merge, rebase this PR onto `main` and rerun the complete validation suite.

## Validation

The live PR’s historical CI is not a current green validation signal: its lint, type-check, bundle-size, Playwright, and classified Web Platform Test checks passed, but its unit-test check failed.

An unpublished maintainer-local reconstruction passed:

- lint;
- type-check and build;
- unit tests with coverage (56 files / 665 tests);
- bundle-size checks;
- the classified Web Platform Test suite (4/4 files); and
- Playwright end-to-end tests (13/13).

These local results are supporting evidence only. Fresh GitHub CI is still required after the live PR is rebased.
