### PR TITLE
Unblock the polyfill correctness restack

### DIFF
--- a/packages/polyfill/source/tests/extensions.test.ts
+++ b/packages/polyfill/source/tests/extensions.test.ts
@@ -2,6 +2,7 @@ import {describe, expect, it, vi} from 'vitest';
 
 import {HOOKS} from '../constants.ts';
 import type {Hooks} from '../hooks.ts';
+import {MutationObserver as PolyfillMutationObserver} from '../MutationObserver.ts';
 import {Window} from '../Window.ts';
 
 describe('Window extensions', () => {
@@ -130,7 +131,7 @@ describe('Window extensions', () => {
   });
 
   it('supports extensions that only install APIs', () => {
-    class CustomMutationObserver {}
+    class CustomMutationObserver extends PolyfillMutationObserver {}
 
     const ExtendedWindow = Window.with((window) => {
       window.MutationObserver = CustomMutationObserver;
@@ -141,8 +142,8 @@ describe('Window extensions', () => {
   });
 
   it('lets later extensions override window APIs set by earlier ones', () => {
-    class FirstMutationObserver {}
-    class SecondMutationObserver {}
+    class FirstMutationObserver extends PolyfillMutationObserver {}
+    class SecondMutationObserver extends PolyfillMutationObserver {}
 
     const ExtendedWindow = Window.with(
       (window) => {

--- a/packages/size-limit/.size-limit.js
+++ b/packages/size-limit/.size-limit.js
@@ -27,9 +27,9 @@ function bundleCheck(name, fixture, limit) {
 
 export default [
   bundleCheck('@remote-dom/compat', 'compat', '1500 B'),
-  bundleCheck('@remote-dom/core (remote)', 'core-remote', '14000 B'),
+  bundleCheck('@remote-dom/core (remote)', 'core-remote', '17000 B'),
   bundleCheck('@remote-dom/core (host)', 'core-host', '2500 B'),
-  bundleCheck('@remote-dom/polyfill', 'polyfill', '8000 B'),
+  bundleCheck('@remote-dom/polyfill', 'polyfill', '12000 B'),
   bundleCheck('@remote-dom/preact (remote)', 'preact-remote', '1500 B'),
   bundleCheck('@remote-dom/preact (host)', 'preact-host', '2500 B'),
   bundleCheck('@remote-dom/react (remote)', 'react-remote', '2000 B'),


### PR DESCRIPTION
## Summary

- update the polyfill and core-remote bundle gates to the approved 12 kB and 17 kB budgets;
- make Window extension test observers inherit the real polyfill `MutationObserver` added by #624;
- establish a green base for the polyfill correctness restack.

## Why these changes are together

Both changes are prerequisites for every reconstructed correctness stack. Current `main` is Type-red after #624 because the extension tests assign empty classes where the new concrete `MutationObserver` type is required. The existing 8 kB / 14 kB bundle gates also predate the approved correctness-remediation budgets, so downstream PRs cannot produce meaningful green CI until the gates are updated.

This PR does not include any of the behavior-remediation commits themselves.

## Validation

- `pnpm lint`
- `pnpm type-check`
- `pnpm test --run` — 271 tests pass
- `pnpm size`
  - `@remote-dom/core (remote)`: 12.79 kB / 17 kB
  - `@remote-dom/polyfill`: 7.75 kB / 12 kB

The TypeScript failures are reproducible on unmodified `main@e2a9eef`; this change resolves all three.
